### PR TITLE
Add client configuration options

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,1 @@
---format documentation
 --color

--- a/lib/digicert/config.rb
+++ b/lib/digicert/config.rb
@@ -1,0 +1,21 @@
+require "digicert/configuration"
+
+module Digicert
+  module Config
+    def configure
+      if block_given?
+        yield configuration
+      end
+    end
+
+    def configuration
+      @configuration ||= Configuration.new
+    end
+  end
+
+  # Expose config module methodas as class level method,
+  # so we can use those method whenever necessary, specially
+  # the `configuration` throughout the gem
+  #
+  extend Config
+end

--- a/lib/digicert/configuration.rb
+++ b/lib/digicert/configuration.rb
@@ -1,0 +1,10 @@
+module Digicert
+  class Configuration
+    attr_accessor :api_host, :base_path
+
+    def initialize
+      @api_host = "www.digicert.com"
+      @base_path = "services/v2"
+    end
+  end
+end

--- a/lib/digicert/endpoint.rb
+++ b/lib/digicert/endpoint.rb
@@ -10,7 +10,14 @@ module Digicert
     API_ORDER_CLIENT_PREMIUM = "#{API_BASE}/order/certificate/client_premium_sha2"
     API_ORDER_VIEW = "/order/certificate/ORDERID"
     API_CERTIFICATE_DOWNLOAD = "/order/certificate/ORDERID"
-    API_ORDER_CLIENT_PREMIUM = "/order/certificate/client_premium_sha2"
+
+    #
+    # This is raising a warning as we might alredy assing
+    # this constent somewhere else, so for now I am just
+    # going to comment this out but I am gonna be back to
+    # this one soon - Abu Nashir, 16th Feb
+    #
+    # API_ORDER_CLIENT_PREMIUM = "/order/certificate/client_premium_sha2"
 
     def new(url)
       URI.encode(URI.decode(url))

--- a/spec/digicert/config_spec.rb
+++ b/spec/digicert/config_spec.rb
@@ -1,0 +1,35 @@
+require "spec_helper"
+require "digicert/config"
+
+RSpec.describe Digicert::Config do
+  after { restore_default_config }
+
+  describe ".configuration" do
+    it "returns the current configuration" do
+      configuration = Digicert.configuration
+
+      expect(configuration.api_host).to eq("www.digicert.com")
+      expect(configuration.base_path).to eq("services/v2")
+    end
+  end
+
+  describe ".configure" do
+    it "allows us to set our custom configuration" do
+      api_host = "www.example.com"
+      base_path = "ping"
+
+      Digicert.configure do |config|
+        config.api_host = api_host
+        config.base_path = base_path
+      end
+
+      expect(Digicert.configuration.api_host).to eq(api_host)
+      expect(Digicert.configuration.base_path).to eq(base_path)
+    end
+  end
+
+  def restore_default_config
+    Digicert.configuration.api_host = "www.digicert.com"
+    Digicert.configuration.base_path = "services/v2"
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 require "bundler/setup"
 require "digicert/api"
+require "digicert/config"
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
@@ -7,5 +8,12 @@ RSpec.configure do |config|
 
   config.expect_with :rspec do |c|
     c.syntax = :expect
+  end
+
+  config.before :all do
+    Digicert.configure do |digicert_config|
+      digicert_config.api_host = "www.digicert.com"
+      digicert_config.base_path = "services/v2"
+    end
   end
 end


### PR DESCRIPTION
This commit adds the configuration option for the API client, It has some predefined defaults, but if necessary then the developer can override those passing a block to the `.configure`.

```ruby
Digicert.configure do |config|
  config.api_host = "www.digicert.com"
  config.base_path = "services/v2"
end
```