### PR TITLE
Add a simple communication wrapper

### DIFF
--- a/digicert-api.gemspec
+++ b/digicert-api.gemspec
@@ -36,4 +36,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.14"
   spec.add_development_dependency "rake", "~> 12.0"
   spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "webmock", "~> 2.0"
 end

--- a/lib/digicert.rb
+++ b/lib/digicert.rb
@@ -7,6 +7,8 @@ require 'curb'
 require 'json'
 require 'pp'
 
+require "digicert/config"
+
 module Digicert
 
   class << self

--- a/lib/digicert/configuration.rb
+++ b/lib/digicert/configuration.rb
@@ -1,6 +1,6 @@
 module Digicert
   class Configuration
-    attr_accessor :api_host, :base_path
+    attr_accessor :api_key, :api_host, :base_path
 
     def initialize
       @api_host = "www.digicert.com"

--- a/lib/digicert/request.rb
+++ b/lib/digicert/request.rb
@@ -1,0 +1,59 @@
+require "uri"
+require "json"
+require "net/http"
+require "digicert/response"
+
+module Digicert
+  class Request
+    def initialize(http_method, end_point, attributes = {})
+      @end_point = end_point
+      @http_method = http_method
+      @attributes = attributes
+    end
+
+    def run
+      Response.new(send_http_request).parse
+    end
+
+    private
+
+    attr_reader :attributes
+
+    def send_http_request
+      Net::HTTP.start(*net_http_options) do |http|
+        request = Net::HTTP::Get.new(uri)
+        set_request_headers!(request)
+        set_request_body!(request)
+        http.request(request)
+      end
+    end
+
+    def net_http_options
+      [uri.host, uri.port, use_ssl: true]
+    end
+
+    def uri
+      URI::HTTPS.build(
+        host: Digicert.configuration.api_host,
+        path: digicert_api_path_with_base,
+      )
+    end
+
+    def set_request_body!(request)
+      unless attributes.empty?
+        request.body = attributes.to_json
+      end
+    end
+
+    def set_request_headers!(request)
+      request.initialize_http_header("Content-Type" => "application/json")
+      request.initialize_http_header(
+        "X-DC-DEVKEY" => Digicert.configuration.api_key,
+      )
+    end
+
+    def digicert_api_path_with_base
+      ["", Digicert.configuration.base_path, @end_point].join("/").squeeze("/")
+    end
+  end
+end

--- a/lib/digicert/response.rb
+++ b/lib/digicert/response.rb
@@ -1,0 +1,16 @@
+require "json"
+require 'ostruct'
+
+module Digicert
+  class Response
+    def initialize(response)
+      @response = response
+    end
+
+    def parse
+      JSON.parse(@response.body || "{}", object_class: ResponseObject)
+    end
+  end
+
+  class ResponseObject < OpenStruct;end
+end

--- a/spec/digicert/request_spec.rb
+++ b/spec/digicert/request_spec.rb
@@ -1,0 +1,19 @@
+require "spec_helper"
+require "digicert/request"
+
+RSpec.describe Digicert::Request do
+  describe "#run" do
+    it "retrieves a resource via a specified http verb" do
+      stub_ping_reqeust_via_get
+      response = Digicert::Request.new(:get, "ping").run
+
+      expect(response.data).to eq("Pong!")
+    end
+  end
+
+  def stub_ping_reqeust_via_get
+    stub_request(:get, "https://www.digicert.com/services/v2/ping").
+      with(headers: { "X-Dc-Devkey"=> Digicert.configuration.api_key }).
+      to_return(status: 200, body: { data: "Pong!"}.to_json )
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,6 @@
+require "webmock/rspec"
 require "bundler/setup"
 require "digicert/api"
-require "digicert/config"
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
@@ -12,8 +12,7 @@ RSpec.configure do |config|
 
   config.before :all do
     Digicert.configure do |digicert_config|
-      digicert_config.api_host = "www.digicert.com"
-      digicert_config.base_path = "services/v2"
+      digicert_config.api_key = "SECRET_DEV_API_KEY"
     end
   end
 end


### PR DESCRIPTION
We need to communicate to the API server and we also need to format some data as necessary, so its ideal to add a wrapper that will wrap around the `net/http` library and format the data as necessary with required headers for the Digicert API.

This commit also adds `webmock`, so we are not performing any live API request while we/ci will run our test suite. This also adds a basic response object, it will parse the API response to `ostruct`