### PR TITLE
Add interface console to play around

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ source_credentials.sh
 .DS_Store
 /.bundle/
 /.yardoc
+/.pryrc
 /Gemfile.lock
 /_yardoc/
 /coverage/

--- a/.sample.pryrc
+++ b/.sample.pryrc
@@ -1,0 +1,3 @@
+Digicert.configure do |config|
+  config.api_key = "YOUR_DEV_API_KEY"
+end

--- a/README.md
+++ b/README.md
@@ -66,3 +66,26 @@ order = Digicert.fetch_order
 
 ```
 
+## Play Box
+
+The API Play Box provides an interactive console so we can easily test out the
+actual API interaction. But before moving forward let's configure the your key.
+
+Setup the client configuration.
+
+```sh
+cp .sample.pryrc .pryrc
+vim .pryrc
+```
+
+Start the console.
+
+```sh
+bin/console
+```
+
+Start playing with it.
+
+```ruby
+Digicert::Product.all
+```

--- a/bin/console
+++ b/bin/console
@@ -9,6 +9,3 @@ require "digicert/api"
 # (If you use this, don't forget to add pry to your Gemfile!)
 require "pry"
 Pry.start
-
-#require "irb"
-#IRB.start(__FILE__)


### PR DESCRIPTION
This commit adds an interactive console to test out the actual API interactions. This commit also adds a `.sample.pryrc` file and you can easily follow the instructions on the `#playbox` section to set it up so you don't have to configure the client every time you want to test it out.