### PR TITLE
Add interface to retrieve a product

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,14 @@ Use this interface to retrieve a list of available products for an account.
 Digicert::Product.all
 ```
 
+#### Product details
+
+Use this interface to retrieve a full set of details for a product.
+
+```ruby
+Digicert::Product.fetch(name_id)
+```
+
 -- Previous usages guide ---
 
 Run `bin/console` for an interactive prompt.

--- a/lib/digicert/product.rb
+++ b/lib/digicert/product.rb
@@ -6,5 +6,9 @@ module Digicert
       response = Digicert::Request.new(:get, "product").run
       response.products
     end
+
+    def self.fetch(name_id)
+      Digicert::Request.new(:get, ["product", name_id].join("/")).run
+    end
   end
 end

--- a/spec/digicert/product_spec.rb
+++ b/spec/digicert/product_spec.rb
@@ -12,4 +12,17 @@ RSpec.describe Digicert::Product do
       expect(products.first.name_id).not_to be_nil
     end
   end
+
+  describe ".fetch" do
+    it "retrieves the specified product" do
+      product_name_id = "ssl_plus"
+
+      stub_digicert_product_fetch_api(product_name_id)
+      product = Digicert::Product.fetch(product_name_id)
+
+      expect(product.name).to eq("SSL Plus")
+      expect(product.type).to eq("ssl_certificate")
+      expect(product.server_platforms.first.name).to eq("Apache")
+    end
+  end
 end

--- a/spec/fixtures/product.json
+++ b/spec/fixtures/product.json
@@ -1,0 +1,71 @@
+{
+  "group_name": "ssl_certificate",
+  "name_id": "ssl_plus",
+  "name": "SSL Plus",
+  "type": "ssl_certificate",
+  "duplicates_allowed": false,
+  "allowed_validity_years": [
+    1,
+    2,
+    3
+  ],
+  "signature_hash_types": {
+    "allowed_hash_types": [
+      {
+        "id": "sha1",
+        "name": "SHA"
+      },
+      {
+        "id": "sha256",
+        "name": "SHA-256"
+      },
+      {
+        "id": "sha384",
+        "name": "SHA-384"
+      },
+      {
+        "id": "sha512",
+        "name": "SHA-512"
+      }
+    ],
+    "default_hash_type_id": "sha256"
+  },
+  "additional_dns_names_allowed": false,
+  "increased_compatibility_allowed": true,
+  "custom_expiration_date_allowed": true,
+  "csr_required": true,
+  "allow_auto_renew": true,
+  "server_platforms": [
+    {
+      "id": 2,
+      "name": "Apache",
+      "install_url": "http:\/\/www.digicert.com\/ssl-certificate-installation-apache.htm",
+      "csr_url": "http:\/\/www.digicert.com\/csr-creation-apache.htm"
+    },
+    {
+      "id": 14,
+      "name": "Microsoft IIS 5 or 6",
+      "install_url": "http:\/\/www.digicert.com\/ssl-certificate-installation-apache.htm",
+      "csr_url": "http:\/\/www.digicert.com\/csr-creation-apache.htm"
+    },
+    {
+      "id": 40,
+      "name": "Microsoft IIS 7",
+      "install_url": "http:\/\/www.digicert.com\/ssl-certificate-installation-apache.htm",
+      "csr_url": "http:\/\/www.digicert.com\/csr-creation-apache.htm"
+    },
+    {
+      "id": 67,
+      "name": "Microsoft IIS 8",
+      "install_url": "http:\/\/www.digicert.com\/ssl-certificate-installation-apache.htm",
+      "csr_url": "http:\/\/www.digicert.com\/csr-creation-apache.htm"
+    },
+    {
+      "id": 68,
+      "name": "Microsoft Exchange Server 2013",
+      "install_url": "http:\/\/www.digicert.com\/ssl-certificate-installation-apache.htm",
+      "csr_url": "http:\/\/www.digicert.com\/csr-creation-apache.htm"
+    }
+  ],
+  "license_agreement": "CERTIFICATE SUBSCRIBER AGREEMENT"
+}

--- a/spec/support/fake_digicert_api.rb
+++ b/spec/support/fake_digicert_api.rb
@@ -6,6 +6,12 @@ module Digicert
       )
     end
 
+    def stub_digicert_product_fetch_api(name_id)
+      stub_api_response(
+        :get, ["product", name_id].join("/"), filename: "product", status: 200,
+      )
+    end
+
     def stub_api_response(method, end_point, filename:, status: 200, data: nil)
       stub_request(method, digicert_api_end_point(end_point)).
         with(digicert_api_request_headers(data: data)).


### PR DESCRIPTION
This commit adds the interface to retrieve a product details using the Digicert Product API, To retrieve a product we need to pass the `name_id` and it will retrieve and initialize a object.

```ruby
Digicert::Product.fetch(name_id)
```