### PR TITLE
Add interface to list all requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,23 +55,14 @@ Use this interface to retrieve a full set of details for a product.
 Digicert::Product.fetch(name_id)
 ```
 
--- Previous usages guide ---
+### Certificate Request
 
-Run `bin/console` for an interactive prompt.
+#### List certificate requests
 
-This is how you run it:
-
-Set your API key in shell:
-```sh
-export DIGICERT_API_KEY="MY-KEY-ID"
-export DIGICERT_TEST_ORDER_ID="MY-ORDER-ID-FOR-TESTING"
-```
+Use this interface to retrieve a list of certificate requests.
 
 ```ruby
-$ bin/console
-orders = Digicert.list_orders
-order = Digicert.fetch_order
-
+Digicert::CertificateRequest.all
 ```
 
 ## Play Box
@@ -96,4 +87,22 @@ Start playing with it.
 
 ```ruby
 Digicert::Product.all
+```
+
+-- Previous usages guide ---
+
+Run `bin/console` for an interactive prompt.
+
+This is how you run it:
+
+Set your API key in shell:
+```sh
+export DIGICERT_API_KEY="MY-KEY-ID"
+export DIGICERT_TEST_ORDER_ID="MY-ORDER-ID-FOR-TESTING"
+```
+
+```ruby
+$ bin/console
+orders = Digicert.list_orders
+order = Digicert.fetch_order
 ```

--- a/lib/digicert.rb
+++ b/lib/digicert.rb
@@ -9,6 +9,7 @@ require 'pp'
 
 require "digicert/config"
 require "digicert/product"
+require "digicert/certificate_request"
 
 module Digicert
 

--- a/lib/digicert/certificate_request.rb
+++ b/lib/digicert/certificate_request.rb
@@ -1,0 +1,10 @@
+require "digicert/request"
+
+module Digicert
+  class CertificateRequest
+    def self.all
+      response = Digicert::Request.new(:get, "request").run
+      response.requests
+    end
+  end
+end

--- a/spec/digicert/certificate_request_spec.rb
+++ b/spec/digicert/certificate_request_spec.rb
@@ -1,0 +1,14 @@
+require "spec_helper"
+
+RSpec.describe Digicert::CertificateRequest do
+  describe ".all" do
+    it "retrieves the lists of certificate requests" do
+      stub_digicert_certificate_request_list_api
+      certificate_requests = Digicert::CertificateRequest.all
+
+      expect(certificate_requests.count).to eq(2)
+      expect(certificate_requests.first.id).not_to be_nil
+      expect(certificate_requests.first.requester.first_name).not_to be_nil
+    end
+  end
+end

--- a/spec/fixtures/certificate_requests.json
+++ b/spec/fixtures/certificate_requests.json
@@ -1,0 +1,59 @@
+{
+  "requests": [
+    {
+      "id": 1,
+      "date": "2014-08-19T18:16:07+00:00",
+      "type": "new_request",
+      "status": "pending",
+      "requester": {
+        "id": 151435,
+        "first_name": "Clive",
+        "last_name": "Collegedean",
+        "email": "clivecollegedean@digicert.com"
+      },
+      "processor": {
+        "id": 154478,
+        "first_name": "John",
+        "last_name": "Smith",
+        "email": "john.smith@digicert.com"
+      },
+      "order": {
+        "id": 542757,
+        "certificate": {
+          "common_name": "www.example.com"
+        },
+        "organization": {
+          "id": 123456,
+          "name": "DigiCert Inc"
+        },
+        "container": {
+          "id": 5,
+          "name": "College of Science"
+        },
+        "product": {
+          "name_id": "ssl_plus",
+          "name": "SSL Plus",
+          "type": "ssl_certificate"
+        }
+      }
+    },
+    {
+      "id": 2,
+      "date": "2014-08-19T18:16:46+00:00",
+      "type": "new_request",
+      "status": "pending",
+      "order": {
+        "id": 542758,
+        "container": {
+          "id": 5,
+          "name": "College of Science"
+        },
+        "product": {
+          "name_id": "ssl_wildcard",
+          "name": "SSL Wildcard",
+          "type": "ssl_certificate"
+        }
+      }
+    }
+  ]
+}

--- a/spec/support/fake_digicert_api.rb
+++ b/spec/support/fake_digicert_api.rb
@@ -12,6 +12,12 @@ module Digicert
       )
     end
 
+    def stub_digicert_certificate_request_list_api
+      stub_api_response(
+        :get, "request", filename: "certificate_requests", status: 200,
+      )
+    end
+
     def stub_api_response(method, end_point, filename:, status: 200, data: nil)
       stub_request(method, digicert_api_end_point(end_point)).
         with(digicert_api_request_headers(data: data)).


### PR DESCRIPTION
This commit adds the interface to retrieve the certificate requests. We used `CertificateRequest` to make the interface more readable, to retrieve the list of certificate requests we can use

```ruby
Digicert::CertificateRequest.all
```