### PR TITLE
Add interface to retrieve a request

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,14 @@ Use this interface to retrieve a list of certificate requests.
 Digicert::CertificateRequest.all
 ```
 
+#### Certificate Request details
+
+Use this interface to retrieve the details for a certificate request.
+
+```ruby
+Digicert::CertificateRequest.fetch(request_id)
+```
+
 ## Play Box
 
 The API Play Box provides an interactive console so we can easily test out the

--- a/lib/digicert/certificate_request.rb
+++ b/lib/digicert/certificate_request.rb
@@ -6,5 +6,9 @@ module Digicert
       response = Digicert::Request.new(:get, "request").run
       response.requests
     end
+
+    def self.fetch(request_id)
+      Digicert::Request.new(:get, ["request", request_id].join("/")).run
+    end
   end
 end

--- a/spec/digicert/certificate_request_spec.rb
+++ b/spec/digicert/certificate_request_spec.rb
@@ -11,4 +11,17 @@ RSpec.describe Digicert::CertificateRequest do
       expect(certificate_requests.first.requester.first_name).not_to be_nil
     end
   end
+
+  describe ".fetch" do
+    it "retrieves the specified certificate request" do
+      request_id = 123_456_789
+
+      stub_digicert_certificate_request_fetch_api(request_id)
+      certificate_request = Digicert::CertificateRequest.fetch(request_id)
+
+      expect(certificate_request.order.id).not_to be_nil
+      expect(certificate_request.status).to eq("pending")
+      expect(certificate_request.requester.first_name).not_to be_nil
+    end
+  end
 end

--- a/spec/fixtures/certificate_request.json
+++ b/spec/fixtures/certificate_request.json
@@ -1,0 +1,116 @@
+{
+  "id": 123456789,
+  "date": "2014-08-19T18:16:07+00:00",
+  "type": "new_request",
+  "status": "pending",
+  "date_processed": "2014-08-19T18:17:07+00:00",
+  "requester": {
+    "id": 151435,
+    "first_name": "Clive",
+    "last_name": "Collegedean",
+    "email": "clivecollegedean@digicert.com"
+  },
+  "processor": {
+    "id": 154478,
+    "first_name": "John",
+    "last_name": "Smith",
+    "email": "john.smith@digicert.com"
+  },
+  "order": {
+    "id": 542757,
+    "certificate": {
+      "common_name": "www.example.com",
+      "dns_names": [
+        "www.example.com"
+      ],
+      "date_created": "2014-12-04T20:32:59+00:00",
+      "csr": "------ [CSR HERE] ------",
+      "organization": {
+        "id": 123456,
+        "name": "DigiCert Inc",
+        "city": "Lehi",
+        "state": "Utah",
+        "country": "US"
+      },
+      "server_platform": {
+        "id": 31,
+        "name": "nginx",
+        "install_url": "https:\/\/www.digicert.com\/ssl-certificate-installation-nginx.htm",
+        "csr_url": "https:\/\/www.digicert.com\/csr-creation-nginx.htm"
+      },
+      "signature_hash": "sha256",
+      "key_size": 2048,
+      "ca_cert": {
+        "id": "1E2F5A55FEA1A",
+        "name": "DigiCert High Assurance SHA2"
+      }
+    },
+    "status": "issued",
+    "is_renewal": true,
+    "date_created": "2014-04-10T19:32:59+00:00",
+    "organization": {
+      "id": 123456,
+      "name": "DigiCert Inc",
+      "city": "Lehi",
+      "state": "Utah",
+      "country": "US"
+    },
+    "validity_years": 2,
+    "disable_renewal_notifications": false,
+    "auto_renew": 0,
+    "container": {
+      "id": 5,
+      "name": "College of Science"
+    },
+    "product": {
+      "name_id": "ssl_plus",
+      "name": "SSL Plus",
+      "type": "ssl_certificate",
+      "validation_type": "code_signing_certificate",
+      "validation_name": "EV CS",
+      "validation_description": "Code Signing Organization Extended Validation (EV CS)"
+    },
+    "organization_contact": {
+      "first_name": "Jay",
+      "last_name": "Smith",
+      "email": "Jay.Smith@digicert.com",
+      "job_title": "VP",
+      "telephone": "8015555555"
+    },
+    "technical_contact": {
+      "first_name": "Jay",
+      "last_name": "Smith",
+      "email": "Jay.Smith@digicert.com",
+      "job_title": "VP",
+      "telephone": "8015555555"
+    },
+    "user": {
+      "id": 4564312,
+      "first_name": "first",
+      "last_name": "name",
+      "email": "first.name@digicert.com"
+    },
+    "requests": [
+      {
+        "id": 4321,
+        "date": "2014-04-10T19:32:59+00:00",
+        "type": "new request",
+        "status": "pending",
+        "comments": "request comments"
+      }
+    ],
+    "cs_provisioning_method": "ship_token",
+    "ship_info": {
+      "name": "Some Guy",
+      "addr1": "333 S 520 W",
+      "addr2": "Suite 500",
+      "city": "Lindon",
+      "state": "Utah",
+      "zip": 84042,
+      "country": "US",
+      "method": "STANDARD"
+    }
+  },
+  "comments": "Comments for the approver",
+  "processor_comment": "Comment left by the person who approved\/rejected the request."
+}

--- a/spec/support/fake_digicert_api.rb
+++ b/spec/support/fake_digicert_api.rb
@@ -18,6 +18,15 @@ module Digicert
       )
     end
 
+    def stub_digicert_certificate_request_fetch_api(request_id)
+      stub_api_response(
+        :get,
+        ["request", request_id].join("/"),
+        filename: "certificate_request",
+        status: 200,
+      )
+    end
+
     def stub_api_response(method, end_point, filename:, status: 200, data: nil)
       stub_request(method, digicert_api_end_point(end_point)).
         with(digicert_api_request_headers(data: data)).


### PR DESCRIPTION
This commit adds the interface to retrieve a specific certificate request details. This interface require us to provide the specific `request_id` and it will find that request and return an object.

```ruby
Digicert::CertificateRequest.featch(request_id)
```