### PR TITLE
Extract common endpoint to base class

### DIFF
--- a/lib/digicert/base.rb
+++ b/lib/digicert/base.rb
@@ -1,0 +1,28 @@
+require "digicert/request"
+
+module Digicert
+  class Base
+    def all
+      response = Digicert::Request.new(:get, resource_path).run
+      response[resources_key]
+    end
+
+    def fetch(name_id)
+      Digicert::Request.new(:get, [resource_path, name_id].join("/")).run
+    end
+
+    def self.method_missing(method_name, *arguments, &block)
+      if new.respond_to?(method_name, include_private: false)
+        new.send(method_name, *arguments, &block)
+      else
+        super
+      end
+    end
+
+    private
+
+    def resources_key
+      [resource_path, "s"].join
+    end
+  end
+end

--- a/lib/digicert/certificate_request.rb
+++ b/lib/digicert/certificate_request.rb
@@ -1,20 +1,18 @@
-require "digicert/request"
+require "digicert/base"
 
 module Digicert
-  class CertificateRequest
-    def self.all
-      response = Digicert::Request.new(:get, "request").run
-      response.requests
-    end
+  class CertificateRequest < Digicert::Base
 
-    def self.fetch(request_id)
-      Digicert::Request.new(:get, ["request", request_id].join("/")).run
-    end
-
-    def self.update(request_id, attributes)
+    def update(request_id, attributes)
       Digicert::Request.new(
-        :put, ["request", request_id, "status"].join("/"), attributes,
+        :put, [resource_path, request_id, "status"].join("/"), attributes,
       ).run
+    end
+
+    private
+
+    def resource_path
+      "request"
     end
   end
 end

--- a/lib/digicert/product.rb
+++ b/lib/digicert/product.rb
@@ -1,14 +1,11 @@
-require "digicert/request"
+require "digicert/base"
 
 module Digicert
-  class Product
-    def self.all
-      response = Digicert::Request.new(:get, "product").run
-      response.products
-    end
+  class Product < Digicert::Base
+    private
 
-    def self.fetch(name_id)
-      Digicert::Request.new(:get, ["product", name_id].join("/")).run
+    def resource_path
+      "product"
     end
   end
 end


### PR DESCRIPTION
So far, we are repeating ourself my implementing the same endpoint in each interface we are adding, so it makes more sense to extract those common behavior to a base class and add `method_missing` to expose our available public method as class methods.