### PR TITLE
Do not expose every single instance methods

### DIFF
--- a/lib/digicert/base.rb
+++ b/lib/digicert/base.rb
@@ -12,16 +12,18 @@ module Digicert
       response[resources_key]
     end
 
-    def fetch(name_id)
-      Digicert::Request.new(:get, [resource_path, name_id].join("/")).run
+    def fetch
+      Digicert::Request.new(
+        :get, [resource_path, @resource_id].join("/"),
+      ).run
     end
 
-    def self.method_missing(method_name, *arguments, &block)
-      if new.respond_to?(method_name, include_private: false)
-        new.send(method_name, *arguments, &block)
-      else
-        super
-      end
+    def self.all
+      new.all
+    end
+
+    def self.fetch(resource_id)
+      new(resource_id: resource_id).fetch
     end
 
     private

--- a/lib/digicert/certificate_request.rb
+++ b/lib/digicert/certificate_request.rb
@@ -3,16 +3,24 @@ require "digicert/base"
 module Digicert
   class CertificateRequest < Digicert::Base
 
-    def update(request_id, attributes)
+    def update
       Digicert::Request.new(
-        :put, [resource_path, request_id, "status"].join("/"), attributes,
+        :put, update_status_path, attributes,
       ).run
+    end
+
+    def self.update(resource_id, attributes)
+      new(resource_id: resource_id, **attributes).update
     end
 
     private
 
     def resource_path
       "request"
+    end
+
+    def update_status_path
+      [resource_path, resource_id, "status"].join("/")
     end
   end
 end


### PR DESCRIPTION
Currently, we are using `method_missing` as a fallback. Just to make it clear when a user's is calling `Product.all` then if the product class did not define the `.all` then it will fall to `method_missing`

Then the `method_missing` checks if that method has already been defined as instance method and if it does then it creates a new object instance and invoke that method method and if that has not been defined then it's passing the default method missing behavior by calling `supper`.

But here come the glitches, it exposes every single instance method as a class method, which is not desirable. So, this commit changes this and add a `is_permitted`, which will verify if the method is included in our white listed class method or not and then handle the other behaviors as before. This will not expose every single methods as class method but the one we have white listed