### PR TITLE
Add interface to order a ssl plus

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,34 @@ Digicert::CertificateRequest.update(
 )
 ```
 
+### Order
+
+#### Order SSL Plus Certificate
+
+Use this interface to order a SSL Plus Certificate.
+
+```ruby
+Digicert::Order::SSLPlus.create(
+  certificate: {
+    common_name: "digicert.com",
+    csr: "------ [CSR HERE] ------",
+    signature_hash: "sha256",
+
+    organization_units: ["Developer Operations"],
+    server_platform: { id: 45 },
+    profile_option: "some_ssl_profile",
+  },
+
+  organization: { id: 117483 },
+  validity_years: 3,
+  custom_expiration_date: "2017-05-18",
+  comments: "Comments for the the approver",
+  disable_renewal_notifications: false,
+  renewal_of_order_id: 314152,
+  payment_method: "balance",
+)
+```
+
 ## Play Box
 
 The API Play Box provides an interactive console so we can easily test out the

--- a/lib/digicert.rb
+++ b/lib/digicert.rb
@@ -10,6 +10,7 @@ require 'pp'
 require "digicert/config"
 require "digicert/product"
 require "digicert/certificate_request"
+require "digicert/order/ssl_plus"
 
 module Digicert
 

--- a/lib/digicert/base.rb
+++ b/lib/digicert/base.rb
@@ -2,6 +2,11 @@ require "digicert/request"
 
 module Digicert
   class Base
+    def initialize(resource_id: nil, **attributes)
+      @resource_id = resource_id
+      @attributes = attributes
+    end
+
     def all
       response = Digicert::Request.new(:get, resource_path).run
       response[resources_key]
@@ -20,6 +25,8 @@ module Digicert
     end
 
     private
+
+    attr_reader :resource_id, :attributes
 
     def resources_key
       [resource_path, "s"].join

--- a/lib/digicert/order/ssl_plus.rb
+++ b/lib/digicert/order/ssl_plus.rb
@@ -1,0 +1,39 @@
+require "digicert/base"
+
+module Digicert
+  module Order
+    class SSLPlus < Digicert::Base
+      def create(certificate:, organization:, validity_years:, **attributes)
+        required_attributes = {
+          certificate: validate_certificate(certificate),
+          organization: validate_organization(organization),
+          validity_years: validity_years,
+        }
+
+        Digicert::Request.new(
+          :post, resource_path, required_attributes.merge(attributes),
+        ).run
+      end
+
+      def self.create(order_attributes)
+        new.create(order_attributes)
+      end
+
+      private
+
+      def resource_path
+        "order/certificate/ssl_plus"
+      end
+
+      def validate_organization(id:)
+        { id: id }
+      end
+
+      def validate_certificate(common_name:, csr:, signature_hash:, **attrs)
+        attrs.merge(
+          csr: csr, common_name: common_name, signature_hash: signature_hash,
+        )
+      end
+    end
+  end
+end

--- a/spec/digicert/order/ssl_plus_spec.rb
+++ b/spec/digicert/order/ssl_plus_spec.rb
@@ -1,0 +1,36 @@
+require "spec_helper"
+
+RSpec.describe Digicert::Order::SSLPlus do
+  describe ".create" do
+    it "creates a new order for ssl plus certificate" do
+      stub_digicert_ssl_plus_create(order_attributes)
+      order = Digicert::Order::SSLPlus.create(order_attributes)
+
+      expect(order.id).not_to be_nil
+      expect(order.requests.first.id).not_to be_nil
+      expect(order.requests.first.status).not_to be_nil
+    end
+  end
+
+  def order_attributes
+    {
+      certificate: {
+        organization_units: ["Developer Operations"],
+        server_platform: { id: 45 },
+        profile_option: "some_ssl_profile",
+
+        # Required for certificate
+        csr: "------ [CSR HERE] ------",
+        common_name: "digicert.com",
+        signature_hash: "sha256",
+      },
+      organization: { id: 117483 },
+      validity_years: 3,
+      custom_expiration_date: "2017-05-18",
+      comments: "Comments for the the approver",
+      disable_renewal_notifications: false,
+      renewal_of_order_id: 314152,
+      payment_method: "balance",
+    }
+  end
+end

--- a/spec/fixtures/ssl_plus_order_created.json
+++ b/spec/fixtures/ssl_plus_order_created.json
@@ -1,0 +1,9 @@
+{
+  "id": 542772,
+  "requests": [
+    {
+      "id": 922432,
+      "status": "pending"
+    }
+  ]
+}

--- a/spec/support/fake_digicert_api.rb
+++ b/spec/support/fake_digicert_api.rb
@@ -37,6 +37,16 @@ module Digicert
       )
     end
 
+    def stub_digicert_ssl_plus_create(attributes)
+      stub_api_response(
+        :post,
+        "order/certificate/ssl_plus",
+        data: attributes,
+        filename: "ssl_plus_order_created",
+        status: 201,
+      )
+    end
+
     def stub_api_response(method, end_point, filename:, status: 200, data: nil)
       stub_request(method, digicert_api_end_point(end_point)).
         with(digicert_api_request_headers(data: data)).


### PR DESCRIPTION
This commit adds the interface to order a ssl plus certificate, this also implements the ruby's hash arguments and will do the basic validation for the required key is being supplied when we try to create a certificate if not then it will raise an error before even making any API call. Usages

```ruby
Digicert::Order::SSLPlus.create(
  certificate: {
    common_name: "digicert.com",
    csr: "------ [CSR HERE] ------",
    signature_hash: "sha256",

    organization_units: ["Developer Operations"],
    server_platform: { id: 45 },
    profile_option: "some_ssl_profile",
  },

  organization: { id: 117483 },
  validity_years: 3,
  custom_expiration_date: "2017-05-18",
  comments: "Comments for the the approver",
  disable_renewal_notifications: false,
  renewal_of_order_id: 314152,
  payment_method: "balance",
)
```