### PR TITLE
Add interface to order SSL Wildcard

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,31 @@ Digicert::Order::SSLPlus.create(
 )
 ```
 
+#### Order SSL Wildcard Certificate
+
+Use this interface to order a SSL Wildcard Certificate.
+
+```ruby
+Digicert::Order::SSLWildcard.create(
+  certificate: {
+    common_name: "digicert.com",
+    csr: "------ [CSR HERE] ------",
+    signature_hash: "sha256",
+
+    organization_units: ["Developer Operations"],
+    server_platform: { id: 45 },
+    profile_option: "some_ssl_profile",
+  },
+
+  organization: { id: 117483 },
+  validity_years: 3,
+  custom_expiration_date: "2017-05-18",
+  comments: "Comments for the the approver",
+  disable_renewal_notifications: false,
+  renewal_of_order_id: 314152,
+)
+```
+
 ## Play Box
 
 The API Play Box provides an interactive console so we can easily test out the

--- a/lib/digicert.rb
+++ b/lib/digicert.rb
@@ -11,6 +11,7 @@ require "digicert/config"
 require "digicert/product"
 require "digicert/certificate_request"
 require "digicert/order/ssl_plus"
+require "digicert/order/ssl_wildcard"
 
 module Digicert
 

--- a/lib/digicert/order/ssl_wildcard.rb
+++ b/lib/digicert/order/ssl_wildcard.rb
@@ -1,0 +1,39 @@
+require "digicert/base"
+
+module Digicert
+  module Order
+    class SSLWildcard < Digicert::Base
+      def create(certificate:, organization:, validity_years:, **attributes)
+        required_attributes = {
+          certificate: validate_certificate(certificate),
+          organization: validate_organization(organization),
+          validity_years: validity_years,
+        }
+
+        Digicert::Request.new(
+          :post, resource_path, required_attributes.merge(attributes),
+        ).run
+      end
+
+      def self.create(order_attributes)
+        new.create(order_attributes)
+      end
+
+      private
+
+      def resource_path
+        "order/certificate/ssl_wildcard"
+      end
+
+      def validate_organization(id:)
+        { id: id }
+      end
+
+      def validate_certificate(common_name:, csr:, signature_hash:, **attrs)
+        attrs.merge(
+          csr: csr, common_name: common_name, signature_hash: signature_hash,
+        )
+      end
+    end
+  end
+end

--- a/spec/digicert/order/ssl_wildcard_spec.rb
+++ b/spec/digicert/order/ssl_wildcard_spec.rb
@@ -1,0 +1,35 @@
+require "spec_helper"
+
+RSpec.describe Digicert::Order::SSLWildcard do
+  describe ".create" do
+    it "creates a new order for a ssl wildcard certificate" do
+      stub_digicert_ssl_wildcard_create_api(order_attributes)
+      order = Digicert::Order::SSLWildcard.create(order_attributes)
+
+      expect(order.id).not_to be_nil
+      expect(order.requests.first.id).not_to be_nil
+      expect(order.requests.first.status).to eq("pending")
+    end
+  end
+
+  def order_attributes
+    {
+      certificate: {
+        organization_units: ["Developer Operations"],
+        server_platform: { id: 45 },
+        profile_option: "some_ssl_profile",
+
+        # Required for certificate
+        csr: "------ [CSR HERE] ------",
+        common_name: "digicert.com",
+        signature_hash: "sha256",
+      },
+      organization: { id: 117483 },
+      validity_years: 3,
+      custom_expiration_date: "2017-05-18",
+      comments: "Comments for the the approver",
+      disable_renewal_notifications: false,
+      renewal_of_order_id: 314152,
+    }
+  end
+end

--- a/spec/fixtures/ssl_wildcard_order_created.json
+++ b/spec/fixtures/ssl_wildcard_order_created.json
@@ -1,0 +1,9 @@
+{
+  "id": 542772,
+  "requests": [
+    {
+      "id": 922432,
+      "status": "pending"
+    }
+  ]
+}

--- a/spec/support/fake_digicert_api.rb
+++ b/spec/support/fake_digicert_api.rb
@@ -47,6 +47,16 @@ module Digicert
       )
     end
 
+    def stub_digicert_ssl_wildcard_create_api(attributes)
+      stub_api_response(
+        :post,
+        "order/certificate/ssl_wildcard",
+        data: attributes,
+        filename: "ssl_wildcard_order_created",
+        status: 201,
+      )
+    end
+
     def stub_api_response(method, end_point, filename:, status: 200, data: nil)
       stub_request(method, digicert_api_end_point(end_point)).
         with(digicert_api_request_headers(data: data)).


### PR DESCRIPTION
This commit adds the interface to order a SSL Wildcard certificate using the Digicert Order API, This has also ensures all required data are provided before making any API call, Usages:

```ruby
Digicert::Order::SSLWildcard.create(
  certificate: {
    common_name: "digicert.com",
    csr: "------ [CSR HERE] ------",
    signature_hash: "sha256",

    organization_units: ["Developer Operations"],
    server_platform: { id: 45 },
    profile_option: "some_ssl_profile",
  },

  organization: { id: 117483 },
  validity_years: 3,
  custom_expiration_date: "2017-05-18",
  comments: "Comments for the the approver",
  disable_renewal_notifications: false,
  renewal_of_order_id: 314152,
)
```