### PR TITLE
Add interface to order SSL EV Plus

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,31 @@ Digicert::Order::SSLWildcard.create(
 )
 ```
 
+#### Order SSL EV Plus Certificate
+
+Use this interface to order a SSL EV Plus Certificate.
+
+```ruby
+Digicert::Order::SSLEVPlus.create(
+  certificate: {
+    common_name: "digicert.com",
+    csr: "------ [CSR HERE] ------",
+    signature_hash: "sha256",
+
+    organization_units: ["Developer Operations"],
+    server_platform: { id: 45 },
+    profile_option: "some_ssl_profile",
+  },
+
+  organization: { id: 117483 },
+  validity_years: 3,
+  custom_expiration_date: "2017-05-18",
+  comments: "Comments for the the approver",
+  disable_renewal_notifications: false,
+  renewal_of_order_id: 314152,
+)
+```
+
 ## Play Box
 
 The API Play Box provides an interactive console so we can easily test out the

--- a/lib/digicert.rb
+++ b/lib/digicert.rb
@@ -12,6 +12,7 @@ require "digicert/product"
 require "digicert/certificate_request"
 require "digicert/order/ssl_plus"
 require "digicert/order/ssl_wildcard"
+require "digicert/order/ssl_ev_plus"
 
 module Digicert
 

--- a/lib/digicert/order/ssl_ev_plus.rb
+++ b/lib/digicert/order/ssl_ev_plus.rb
@@ -1,0 +1,13 @@
+require "digicert/order/base"
+
+module Digicert
+  module Order
+    class SSLEVPlus < Digicert::Order::Base
+      private
+
+      def certificate_type
+        "ssl_ev_plus"
+      end
+    end
+  end
+end

--- a/spec/digicert/order/ssl_ev_plus_spec.rb
+++ b/spec/digicert/order/ssl_ev_plus_spec.rb
@@ -1,0 +1,35 @@
+require "spec_helper"
+
+RSpec.describe Digicert::Order::SSLEVPlus do
+  describe ".create" do
+    it "creates a new order for a SSL EV Plus certificate" do
+      stub_digicert_order_create_api("ssl_ev_plus", order_attributes)
+      order = Digicert::Order::SSLEVPlus.create(order_attributes)
+
+      expect(order.id).not_to be_nil
+      expect(order.requests.first.id).not_to be_nil
+      expect(order.requests.first.status).to eq("pending")
+    end
+  end
+
+  def order_attributes
+    {
+      certificate: {
+        organization_units: ["Developer Operations"],
+        server_platform: { id: 45 },
+        profile_option: "some_ssl_profile",
+
+        # Required for certificate
+        csr: "------ [CSR HERE] ------",
+        common_name: "digicert.com",
+        signature_hash: "sha256",
+      },
+      organization: { id: 117483 },
+      validity_years: 3,
+      custom_expiration_date: "2017-05-18",
+      comments: "Comments for the the approver",
+      disable_renewal_notifications: false,
+      renewal_of_order_id: 314152,
+    }
+  end
+end


### PR DESCRIPTION
This commit adds the interface to order a SSL EV Plus certificate using the Digicert Order Creation API. The implementation is very simple, it's just inheriting the `Digicert::Order::Base` and that is handling all the underlying communication.

```ruby
Digicert::Order::SSLEVPlus.create(
  certificate: {
    common_name: "digicert.com",
    csr: "------ [CSR HERE] ------",
    signature_hash: "sha256",

    organization_units: ["Developer Operations"],
    server_platform: { id: 45 },
    profile_option: "some_ssl_profile",
  },

  organization: { id: 117483 },
  validity_years: 3,
  custom_expiration_date: "2017-05-18",
  comments: "Comments for the the approver",
  disable_renewal_notifications: false,
  renewal_of_order_id: 314152,
)
```