### PR TITLE
Add interface to order premium certificate

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,32 @@ Digicert::Order::SSLEVPlus.create(
 )
 ```
 
+#### Order Client Premium Certificate
+
+Use this interface to order a Client Premium Certificate.
+
+```ruby
+Digicert::Order::ClientPremium.create(
+  certificate: {
+    common_name: "digicert.com",
+    emails: ["email@example.com", "email1@example.com"],
+    csr: "------ [CSR HERE] ------",
+    signature_hash: "sha256",
+
+    organization_units: ["Developer Operations"],
+    server_platform: { id: 45 },
+    profile_option: "some_ssl_profile",
+  },
+
+  organization: { id: 117483 },
+  validity_years: 3,
+  custom_expiration_date: "2017-05-18",
+  comments: "Comments for the the approver",
+  disable_renewal_notifications: false,
+  renewal_of_order_id: 314152,
+)
+```
+
 ## Play Box
 
 The API Play Box provides an interactive console so we can easily test out the

--- a/lib/digicert.rb
+++ b/lib/digicert.rb
@@ -13,6 +13,7 @@ require "digicert/certificate_request"
 require "digicert/order/ssl_plus"
 require "digicert/order/ssl_wildcard"
 require "digicert/order/ssl_ev_plus"
+require "digicert/order/client_premium"
 
 module Digicert
 

--- a/lib/digicert/order/client_premium.rb
+++ b/lib/digicert/order/client_premium.rb
@@ -1,0 +1,17 @@
+require "digicert/order/base"
+
+module Digicert
+  module Order
+    class ClientPremium < Digicert::Order::Base
+      private
+
+      def certificate_type
+        "client_premium_sha2"
+      end
+
+      def validate_certificate(emails:, **attributes)
+        super(attributes.merge(emails: emails))
+      end
+    end
+  end
+end

--- a/spec/digicert/order/client_premium_spec.rb
+++ b/spec/digicert/order/client_premium_spec.rb
@@ -1,0 +1,34 @@
+require "spec_helper"
+
+RSpec.describe Digicert::Order::ClientPremium do
+  describe ".create" do
+    it "creates a new order for a client premium certificate" do
+      stub_digicert_order_create_api("client_premium_sha2", order_attributes)
+      order = Digicert::Order::ClientPremium.create(order_attributes)
+
+      expect(order.id).not_to be_nil
+    end
+  end
+
+  def order_attributes
+    {
+      certificate: {
+        organization_units: ["Developer Operations"],
+        server_platform: { id: 45 },
+        profile_option: "some_ssl_profile",
+
+        # Required for certificate
+        emails: ["email@example.com", "email1@example.com"],
+        csr: "------ [CSR HERE] ------",
+        common_name: "digicert.com",
+        signature_hash: "sha256",
+      },
+      organization: { id: 117483 },
+      validity_years: 3,
+      custom_expiration_date: "2017-05-18",
+      comments: "Comments for the the approver",
+      disable_renewal_notifications: false,
+      renewal_of_order_id: 314152,
+    }
+  end
+end


### PR DESCRIPTION
This commit adds the interface to order a client premium certificate using the Digicert Order API. This type of orders also requires an additional required parameters `emails` for the certificate hash, so we did override the existing `validate_certificate` to impose the `emails` as required arguments. Usages

```ruby
Digicert::Order::ClientPremium.create(
  certificate: {
    common_name: "digicert.com",
    emails: ["email@example.com", "email1@example.com"],
    csr: "------ [CSR HERE] ------",
    signature_hash: "sha256",

    organization_units: ["Developer Operations"],
    server_platform: { id: 45 },
    profile_option: "some_ssl_profile",
  },

  organization: { id: 117483 },
  validity_years: 3,
  custom_expiration_date: "2017-05-18",
  comments: "Comments for the the approver",
  disable_renewal_notifications: false,
  renewal_of_order_id: 314152,
)
```