### PR TITLE
Add interface to order email plus cert

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ Use this interface to order a Client Premium Certificate.
 ```ruby
 Digicert::Order::ClientPremium.create(
   certificate: {
-    common_name: "digicert.com",
+    common_name: "Full Name",
     emails: ["email@example.com", "email1@example.com"],
     csr: "------ [CSR HERE] ------",
     signature_hash: "sha256",
@@ -184,6 +184,29 @@ Digicert::Order::ClientPremium.create(
   custom_expiration_date: "2017-05-18",
   comments: "Comments for the the approver",
   disable_renewal_notifications: false,
+  renewal_of_order_id: 314152,
+)
+```
+
+#### Order Email Security Plus
+
+Use this interface to order a Email Security Plus Certificate
+
+```ruby
+Digicert::EmailSecurityPlus.create(
+  certificate: {
+    common_name: "Full Name",
+    emails: ["email@example.com", "email1@example.com"],
+    signature_hash: "sha256",
+
+    organization_units: ["Developer Operations"],
+    server_platform: { id: 45 },
+    profile_option: "some_ssl_profile",
+  },
+
+  organization: { id: 117483 },
+  validity_years: 3,
+  auto_renew: 10,
   renewal_of_order_id: 314152,
 )
 ```

--- a/lib/digicert.rb
+++ b/lib/digicert.rb
@@ -14,6 +14,7 @@ require "digicert/order/ssl_plus"
 require "digicert/order/ssl_wildcard"
 require "digicert/order/ssl_ev_plus"
 require "digicert/order/client_premium"
+require "digicert/order/email_security_plus"
 
 module Digicert
 

--- a/lib/digicert/order/email_security_plus.rb
+++ b/lib/digicert/order/email_security_plus.rb
@@ -1,0 +1,21 @@
+require "digicert/order/base"
+
+module Digicert
+  module Order
+    class EmailSecurityPlus < Digicert::Order::Base
+      private
+
+      def certificate_type
+        "client_email_security_plus"
+      end
+
+      def validate_certificate(common_name:, signature_hash:, emails:, **attrs)
+        attrs.merge(
+          emails: emails,
+          common_name: common_name,
+          signature_hash: signature_hash,
+        )
+      end
+    end
+  end
+end

--- a/spec/digicert/order/email_security_plus_spec.rb
+++ b/spec/digicert/order/email_security_plus_spec.rb
@@ -1,0 +1,34 @@
+require "spec_helper"
+
+RSpec.describe Digicert::Order::EmailSecurityPlus do
+  describe ".create" do
+    it "creates a new order for a email security plus certificate" do
+      stub_digicert_order_create_api(
+        "client_email_security_plus", order_attributes,
+      )
+
+      order = Digicert::Order::EmailSecurityPlus.create(order_attributes)
+
+      expect(order.id).not_to be_nil
+    end
+  end
+
+  def order_attributes
+    {
+      certificate: {
+        organization_units: ["Developer Operations"],
+        server_platform: { id: 45 },
+        profile_option: "some_ssl_profile",
+
+        # Required for certificate
+        emails: ["email@example.com", "email1@example.com"],
+        common_name: "Full Name",
+        signature_hash: "sha256",
+      },
+      organization: { id: 117483 },
+      validity_years: 3,
+      auto_renew: 10,
+      renewal_of_order_id: 314152,
+    }
+  end
+end


### PR DESCRIPTION
This commit adds the interface to order a client email security certificate using the Digicert Order API. The certificate needs a minor different behavior then others so it overrides the base method and adds the required arguments and removes the others

```ruby
Digicert::EmailSecurityPlus.create(
  certificate: {
    common_name: "Full Name",
    emails: ["email@example.com", "email1@example.com"],
    signature_hash: "sha256",

    organization_units: ["Developer Operations"],
    server_platform: { id: 45 },
    profile_option: "some_ssl_profile",
  },

  organization: { id: 117483 },
  validity_years: 3,
  auto_renew: 10,
  renewal_of_order_id: 314152,
)
```