### PR TITLE
Add interface to order signature plus

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,26 @@ Digicert::EmailSecurityPlus.create(
 )
 ```
 
+#### Order Client Digital Signature Plus
+
+Use this interface to order a Order Client Digital Signature Plus
+
+```ruby
+Digicert::DigitalSignaturePlus.create(
+  certificate: {
+    common_name: "Full Name",
+    emails: ["email@example.com", "email1@example.com"],
+    csr: "-----BEGIN CERTIFICATE REQUEST----- ...",
+    signature_hash: "sha256",
+  },
+
+  organization: { id: 117483 },
+  validity_years: 3,
+  auto_renew: 10,
+  renewal_of_order_id: 314152,
+)
+```
+
 ## Play Box
 
 The API Play Box provides an interactive console so we can easily test out the

--- a/lib/digicert.rb
+++ b/lib/digicert.rb
@@ -15,6 +15,7 @@ require "digicert/order/ssl_wildcard"
 require "digicert/order/ssl_ev_plus"
 require "digicert/order/client_premium"
 require "digicert/order/email_security_plus"
+require "digicert/order/digital_signature_plus"
 
 module Digicert
 

--- a/lib/digicert/order/digital_signature_plus.rb
+++ b/lib/digicert/order/digital_signature_plus.rb
@@ -1,0 +1,17 @@
+require "digicert/order/base"
+
+module Digicert
+  module Order
+    class DigitalSignaturePlus < Digicert::Order::Base
+      private
+
+      def certificate_type
+        "client_digital_signature_plus"
+      end
+
+      def validate_certificate(emails:, **attributes)
+        super(attributes.merge(emails: emails))
+      end
+    end
+  end
+end

--- a/spec/digicert/order/digital_signature_plus_spec.rb
+++ b/spec/digicert/order/digital_signature_plus_spec.rb
@@ -1,0 +1,31 @@
+require "spec_helper"
+
+RSpec.describe Digicert::Order::DigitalSignaturePlus do
+  describe ".create" do
+    it "creates a new order for a digital signature plus certificate" do
+      stub_digicert_order_create_api(
+        "client_digital_signature_plus", order_attributes,
+      )
+
+      order = Digicert::Order::DigitalSignaturePlus.create(order_attributes)
+
+      expect(order.id).not_to be_nil
+    end
+  end
+
+  def order_attributes
+    {
+      certificate: {
+        # Required for certificate
+        emails: ["email@example.com", "email1@example.com"],
+        csr: "-----BEGIN CERTIFICATE REQUEST----- ...",
+        common_name: "Full Name",
+        signature_hash: "sha256",
+      },
+      organization: { id: 117483 },
+      validity_years: 3,
+      auto_renew: 10,
+      renewal_of_order_id: 314152,
+    }
+  end
+end


### PR DESCRIPTION
This commit adds the interface to order a Digital Signature Plus using the Digicert Order API, This also overrides the arguments for `validate_certificate` method, Usage:

```ruby
Digicert::DigitalSignaturePlus.create(
  certificate: {
    common_name: "Full Name",
    emails: ["email@example.com", "email1@example.com"],
    csr: "-----BEGIN CERTIFICATE REQUEST----- ...",
    signature_hash: "sha256",
  },

  organization: { id: 117483 },
  validity_years: 3,
  auto_renew: 10,
  renewal_of_order_id: 314152,
)
```