### PR TITLE
Add interface to fetch certificate order

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,16 @@ Digicert::DigitalSignaturePlus.create(
 )
 ```
 
+### Certificate Order
+
+#### Certificate order details
+
+Use this interface to retrieve a certificate order.
+
+```ruby
+Digicert::CertificateOrder.fetch(order_id)
+```
+
 ## Play Box
 
 The API Play Box provides an interactive console so we can easily test out the

--- a/lib/digicert.rb
+++ b/lib/digicert.rb
@@ -16,6 +16,7 @@ require "digicert/order/ssl_ev_plus"
 require "digicert/order/client_premium"
 require "digicert/order/email_security_plus"
 require "digicert/order/digital_signature_plus"
+require "digicert/certificate_order"
 
 module Digicert
 

--- a/lib/digicert/certificate_order.rb
+++ b/lib/digicert/certificate_order.rb
@@ -1,0 +1,11 @@
+require "digicert/base"
+
+module Digicert
+  class CertificateOrder < Digicert::Base
+    private
+
+    def resource_path
+      "order/certificate/"
+    end
+  end
+end

--- a/spec/acceptance/certificate_download_spec.rb
+++ b/spec/acceptance/certificate_download_spec.rb
@@ -1,0 +1,49 @@
+require "spec_helper"
+require "digicert"
+
+RSpec.describe "Download a certificate" do
+  it "creates and download a certificate" do
+    name_id = "ssl_plus"
+
+    # Retrieve the product details uisng the
+    # name id specificed for that specific one
+    #
+    stub_digicert_product_fetch_api(name_id)
+    product = Digicert::Product.fetch(name_id)
+
+    # Order a new certificate using the product details
+    # server platform, signature hash and other fields
+    #
+    order_attributes = build_order_attributes(product)
+    stub_digicert_order_create_api("ssl_plus", order_attributes)
+    order = Digicert::Order::SSLPlus.create(order_attributes)
+
+    # Retrieve the certificate order details with the
+    # certificate id in it, so we can use this one to
+    # download the certificate using the API
+    #
+    stub_digicert_certificate_order_fetch_api(order.id)
+    certificate_order = Digicert::CertificateOrder.fetch(order.id)
+
+    expect(certificate_order.certificate.id).not_to be_nil
+  end
+
+  def build_order_attributes(product)
+    {
+      certificate: {
+        organization_units: ["Developer Operations"],
+        server_platform: { id: product.server_platforms.first.id },
+        profile_option: "some_ssl_profile",
+
+        csr: "------ [CSR HERE] ------",
+        common_name: "digicert.com",
+        signature_hash: product.signature_hash_types.allowed_hash_types[0].id,
+      },
+      organization: { id: 117483 },
+      validity_years: product.allowed_validity_years.last,
+      disable_renewal_notifications: false,
+      renewal_of_order_id: 314152,
+      payment_method: "balance",
+    }
+  end
+end

--- a/spec/digicert/certificate_order_spec.rb
+++ b/spec/digicert/certificate_order_spec.rb
@@ -1,0 +1,16 @@
+require "spec_helper"
+
+RSpec.describe Digicert::CertificateOrder do
+  describe ".fetch" do
+    it "retrieves the specific certificate order" do
+      order_id = 123_456_789
+
+      stub_digicert_certificate_order_fetch_api(order_id)
+      certificate_order = Digicert::CertificateOrder.fetch(order_id)
+
+      expect(certificate_order.id).not_to be_nil
+      expect(certificate_order.status).to eq("approved")
+      expect(certificate_order.certificate.id).not_to be_nil
+    end
+  end
+end

--- a/spec/fixtures/order.json
+++ b/spec/fixtures/order.json
@@ -1,0 +1,107 @@
+{
+  "id": 123456789,
+  "certificate": {
+    "id": 112358,
+    "thumbprint": "7D236B54D19D5EACF0881FAF24D51DFE5D23E945",
+    "serial_number": "0669D46CAE79EF684A69777490602485",
+    "common_name": "digicert.com",
+    "dns_names": [
+      "digicert.com"
+    ],
+    "date_created": "2014-08-19T18:16:07+00:00",
+    "valid_from": "2014-08-19",
+    "valid_till": "2015-08-19",
+    "csr": "------ [CSR HERE] ------",
+    "organization": {
+      "id": 117483
+    },
+    "organization_units": [
+      "Digicert"
+    ],
+    "server_platform": {
+      "id": 45,
+      "name": "nginx",
+      "install_url": "https:\/\/www.digicert.com\/ssl-certificate-installation-nginx.htm",
+      "csr_url": "https:\/\/www.digicert.com\/csr-creation-nginx.htm"
+    },
+    "signature_hash": "sha256",
+    "key_size": 2048,
+    "ca_cert": {
+      "id": "f7slk4shv9s2wr3",
+      "name": "DCert Private CA"
+    }
+  },
+  "status": "approved",
+  "is_renewal": true,
+  "is_renewed": false,
+  "renewed_order_id": 0,
+  "business_unit": "Some Unit",
+  "date_created": "2014-08-19T18:16:07+00:00",
+  "organization": {
+    "name": "DigiCert, Inc.",
+    "display_name": "DigiCert, Inc.",
+    "is_active": true,
+    "city": "Lindon",
+    "state": "Utah",
+    "country": "us"
+  },
+  "disable_renewal_notifications": false,
+  "container": {
+    "id": 5,
+    "name": "College of Science"
+  },
+  "product": {
+    "name_id": "ssl_plus",
+    "name": "SSL Plus",
+    "type": "ssl_certificate",
+    "validation_type": "ov",
+    "validation_name": "OV",
+    "validation_description": "Normal Organization Validation"
+  },
+  "organization_contact": {
+    "first_name": "Some",
+    "last_name": "Guy",
+    "email": "someguy@digicert.com",
+    "telephone": "8015551212"
+  },
+  "technical_contact": {
+    "first_name": "Some",
+    "last_name": "Guy",
+    "email": "someguy@digicert.com",
+    "telephone": "8015551212"
+  },
+  "user": {
+    "id": 153208,
+    "first_name": "Clive",
+    "last_name": "Collegedean",
+    "email": "clivecollegedean@digicert.com"
+  },
+  "requests": [
+    {
+      "id": 1,
+      "date": "2015-01-01T18:20:00+00:00",
+      "type": "new_request",
+      "status": "approved",
+      "comments": "Form autofill"
+    }
+  ],
+  "receipt_id": 123892,
+  "cs_provisioning_method": "none",
+  "send_minus_90": true,
+  "send_minus_60": true,
+  "send_minus_30": true,
+  "send_minus_7": true,
+  "send_minus_3": true,
+  "send_plus_7": true,
+  "public_id": "MZv8RhHDVl9R3Ieko3iMX89wvYT3bYPA",
+  "allow_duplicates": false,
+  "user_assignments": [
+    {
+      "id": 153208,
+      "first_name": "Clive",
+      "last_name": "Collegedean",
+      "email": "clivecollegedean@digicert.com"
+    }
+  ],
+  "payment_method": "balance"
+}

--- a/spec/support/fake_digicert_api.rb
+++ b/spec/support/fake_digicert_api.rb
@@ -47,6 +47,12 @@ module Digicert
       )
     end
 
+    def stub_digicert_certificate_order_fetch_api(order_id)
+      stub_api_response(
+        :get, ["order/certificate", order_id].join("/"), filename: "order",
+      )
+    end
+
     def stub_api_response(method, end_point, filename:, status: 200, data: nil)
       stub_request(method, digicert_api_end_point(end_point)).
         with(digicert_api_request_headers(data: data)).


### PR DESCRIPTION
This commit adds the interface to retrieve the order details with the certificate for a specific order id. To retrieve the details we need to pass the `order_id` and it will return the order with the certificate, product and status in it. Usages

```ruby
Digicert::CertificateOrder.fetch(order_id)
```