### PR TITLE
Add interface to list organizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,16 @@ Use this interface to retrieve a certificate order.
 Digicert::CertificateOrder.fetch(order_id)
 ```
 
+### Organization
+
+#### List all organizations
+
+Use this interface to retrieve a list of organizations.
+
+```ruby
+Digicert::Organization.all
+```
+
 ## Play Box
 
 The API Play Box provides an interactive console so we can easily test out the

--- a/lib/digicert.rb
+++ b/lib/digicert.rb
@@ -17,6 +17,7 @@ require "digicert/order/client_premium"
 require "digicert/order/email_security_plus"
 require "digicert/order/digital_signature_plus"
 require "digicert/certificate_order"
+require "digicert/organization"
 
 module Digicert
 
@@ -51,7 +52,6 @@ end
 require 'digicert/client'
 require 'digicert/endpoint'
 require 'digicert/order'
-require 'digicert/organization'
 require 'digicert/certificate'
 
 

--- a/lib/digicert/organization.rb
+++ b/lib/digicert/organization.rb
@@ -2,26 +2,14 @@
 # (c) 2017 Ribose, Inc. as unpublished work.
 #
 #
+require "digicert/base"
 
 module Digicert
-  class Organization
+  class Organization < Digicert::Base
+    private
 
-    GENERATED_ATTRS = %i(
-      id
-      name
-      display_name
-      is_active
-      city
-      state
-      country
-    )
-    attr_accessor *GENERATED_ATTRS
-
-    def initialize options={}
-      options.each_pair do |k, v|
-        send("#{k}=", v)
-      end
+    def resource_path
+      "organization"
     end
   end
 end
-

--- a/spec/acceptance/certificate_download_spec.rb
+++ b/spec/acceptance/certificate_download_spec.rb
@@ -39,11 +39,16 @@ RSpec.describe "Download a certificate" do
         common_name: "digicert.com",
         signature_hash: product.signature_hash_types.allowed_hash_types[0].id,
       },
-      organization: { id: 117483 },
+      organization: { id: organizations.first.id },
       validity_years: product.allowed_validity_years.last,
       disable_renewal_notifications: false,
       renewal_of_order_id: 314152,
       payment_method: "balance",
     }
+  end
+
+  def organizations
+    stub_digicert_organization_list_api
+    Digicert::Organization.all
   end
 end

--- a/spec/digicert/organization_spec.rb
+++ b/spec/digicert/organization_spec.rb
@@ -1,0 +1,15 @@
+require "spec_helper"
+
+RSpec.describe Digicert::Organization do
+  describe ".all" do
+    it "retrieves the list of organizations" do
+      stub_digicert_organization_list_api
+      organizations = Digicert::Organization.all
+
+      expect(organizations.first.id).not_to be_nil
+      expect(organizations.first.name).not_to be_nil
+      expect(organizations.first.is_active).to eq(true)
+      expect(organizations.first.container.id).not_to be_nil
+    end
+  end
+end

--- a/spec/fixtures/organizations.json
+++ b/spec/fixtures/organizations.json
@@ -1,0 +1,84 @@
+{
+  "organizations": [
+    {
+      "id": 117483,
+      "status": "approved",
+      "name": "DigiCert, Inc.",
+      "assumed_name": "DigiCert",
+      "display_name": "DigiCert, Inc. (DigiCert)",
+      "is_active": true,
+      "address": "333 S 520 W",
+      "address2": "Suite 500",
+      "zip": "84042",
+      "city": "Lindon",
+      "state": "Utah",
+      "country": "US",
+      "telephone": "801-555-0453",
+      "container": {
+        "id": 1,
+        "name": "My Company",
+        "is_active": true
+      },
+      "validations": [
+        {
+          "type": "ov",
+          "name": "OV",
+          "description": "Normal Organization Validation",
+          "date_created": "2015-08-09T17:04:59+00:00",
+          "validated_until": "2016-08-09T17:04:45+00:00",
+          "status": "active"
+        },
+        {
+          "type": "ev",
+          "name": "EV",
+          "description": "Extended Organization Validation (EV)",
+          "status": "pending",
+          "verified_users": [
+            {
+              "id": 1,
+              "first_name": "John",
+              "last_name": "Harrison"
+            }
+          ]
+        },
+        {
+          "type": "cs",
+          "name": "CS",
+          "description": "Code Signing Validation",
+          "date_created": "2014-08-09T17:04:59+00:00",
+          "validated_until": "2015-08-09T17:04:45+00:00",
+          "status": "expired",
+          "verified_users": [
+            {
+              "id": 1,
+              "first_name": "John",
+              "last_name": "Harrison"
+            }
+          ]
+        }
+      ],
+      "ev_approvers": [
+        {
+          "id": 4321,
+          "first_name": "Bro",
+          "last_name": "Jackson"
+        }
+      ]
+    },
+    {
+      "id": 117483,
+      "status": "approved",
+      "name": "Testing, Inc.",
+      "address": "123 Testing Way",
+      "zip": "84043",
+      "city": "Lehi",
+      "state": "Utah",
+      "country": "US",
+      "container": {
+        "id": 1,
+        "name": "My Company",
+        "is_active": true
+      }
+    }
+  ]
+}

--- a/spec/support/fake_digicert_api.rb
+++ b/spec/support/fake_digicert_api.rb
@@ -53,6 +53,12 @@ module Digicert
       )
     end
 
+    def stub_digicert_organization_list_api
+      stub_api_response(
+        :get, "organization", filename: "organizations", status: 200,
+      )
+    end
+
     def stub_api_response(method, end_point, filename:, status: 200, data: nil)
       stub_request(method, digicert_api_end_point(end_point)).
         with(digicert_api_request_headers(data: data)).


### PR DESCRIPTION
We need an `organization_id` along with the `order` attributes to submit any valid certificate request, but we did not have any way to retrieve the organizations easily.

This commit adds the interface to retrieve the list of all the organizations associated with the account, it also includes the `container` which can be used in some use case scenario

```ruby
Digicert::Organization.all
```