### PR TITLE
Add unified interface to create order

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,47 @@ Digicert::CertificateRequest.update(
 
 ### Order
 
+### Create a new order
+
+Use this interface to create a new order, this expect two arguments one is
+`name_id` for the order and another one is the attributes hash for the order.
+
+```ruby
+order = Digicert::Order.create(
+  name_id, order_attributes_hash,
+)
+
+# Pay close attension building the order attributes
+# hash, it requries to format the data in a specific
+# format and once that is satisfied only then it will
+# perfrom the API operation otherwise it will raise
+# invalid argument errors.
+#
+order_attributes = {
+  certificate: {
+    common_name: "digicert.com",
+    csr: "------ [CSR HERE] ------",
+    signature_hash: "sha256",
+
+    organization_units: ["Developer Operations"],
+    server_platform: { id: 45 },
+    profile_option: "some_ssl_profile",
+  },
+
+  organization: { id: 117483 },
+  validity_years: 3,
+  custom_expiration_date: "2017-05-18",
+  comments: "Comments for the the approver",
+  disable_renewal_notifications: false,
+  renewal_of_order_id: 314152,
+  payment_method: "balance",
+}
+```
+
+The supported `name_id`'s are `ssl_plus`, `ssl_wildcard`, `ssl_ev_plus`,
+`client_premium`, `email_security_plus` and `digital_signature_plus`. Please
+check the Digicert documentation for more details on those.
+
 #### Order SSL Plus Certificate
 
 Use this interface to order a SSL Plus Certificate.

--- a/lib/digicert.rb
+++ b/lib/digicert.rb
@@ -9,9 +9,8 @@ require 'pp'
 
 require "digicert/config"
 require "digicert/product"
+require "digicert/order"
 require "digicert/certificate_request"
-require "digicert/ssl_certificate"
-require "digicert/client_certificate"
 require "digicert/certificate_order"
 require "digicert/organization"
 
@@ -45,10 +44,10 @@ module Digicert
 end
 
 
-require 'digicert/client'
-require 'digicert/endpoint'
-require 'digicert/order'
-require 'digicert/certificate'
+# require 'digicert/client'
+# require 'digicert/endpoint'
+# require 'digicert/order'
+# require 'digicert/certificate'
 
 
 __END__

--- a/lib/digicert/base_order.rb
+++ b/lib/digicert/base_order.rb
@@ -1,6 +1,47 @@
-require "digicert/order/base"
+require "digicert/base"
 
 module Digicert
-  class BaseOrder < Digicert::Order::Base
+  class BaseOrder < Digicert::Base
+    def create(certificate:, organization:, validity_years:, **attributes)
+      required_attributes = {
+        certificate: validate_certificate(certificate),
+        organization: validate_organization(organization),
+        validity_years: validity_years,
+      }
+
+      create_order(required_attributes, attributes)
+    end
+
+    def self.create(order_attributes)
+      new.create(order_attributes)
+    end
+
+    private
+
+    def create_order(required_attrs, additional_attrs)
+      Digicert::Request.new(
+        :post, order_creation_path, required_attrs.merge(additional_attrs),
+      ).run
+    end
+
+    def order_creation_path
+      [resource_path, certificate_type].join("/")
+    end
+
+    def resource_path
+      "order/certificate"
+    end
+
+    def validate_organization(id:)
+      { id: id }
+    end
+
+    def validate_certificate(common_name:, csr:, signature_hash:, **attrs)
+      attrs.merge(
+        csr: csr,
+        common_name: common_name,
+        signature_hash: signature_hash,
+      )
+    end
   end
 end

--- a/lib/digicert/client_certificate.rb
+++ b/lib/digicert/client_certificate.rb
@@ -1,8 +1,0 @@
-require "digicert/client_certificate/premium"
-require "digicert/client_certificate/email_security_plus"
-require "digicert/client_certificate/digital_signature_plus"
-
-module Digicert
-  module ClientCertificate
-  end
-end

--- a/lib/digicert/order.rb
+++ b/lib/digicert/order.rb
@@ -3,67 +3,47 @@
 #
 #
 
+require "digicert/ssl_certificate/ssl_plus"
+require "digicert/ssl_certificate/ssl_ev_plus"
+require "digicert/ssl_certificate/ssl_wildcard"
+
+require "digicert/client_certificate/premium"
+require "digicert/client_certificate/email_security_plus"
+require "digicert/client_certificate/digital_signature_plus"
+
 module Digicert
-  module Order
-    class << self
-      # https://www.digicert.com/services/v2/order/certificate
-
-      # TODO: support pagination according to API
-      def list
-        orders = Digicert.client.perform("https://www.digicert.com/services/v2/order/certificate") do |curl|
-          curl.headers["Accept"] = "application/json"
-          curl.verbose = true
-        end
-
-        orders["orders"].map do |o|
-          instantiate_by_type o
-        end
-      end
-
-      def fetch_by_id(order_id)
-        order = Digicert.client.perform("https://www.digicert.com/services/v2/order/certificate/#{order_id}") do |curl|
-          curl.headers["Accept"] = "application/json"
-          curl.verbose = true
-        end
-
-        pp order
-
-        instantiate_by_type order
-      end
-
-      def instantiate_by_type order_hash
-
-        puts 'instantiate_by_type'
-        pp order_hash
-
-        case order_hash["product"]["name_id"]
-        when "ssl_plus",
-          "ssl_wildcard"
-          Ssl.new order_hash
-
-        when "ssl_ev_plus"
-          EvSsl.new order_hash
-
-        when "client_premium",
-          "client_email_security_plus",
-          "client_digital_signature_plus"
-
-          EvSsl.new order_hash
-
-        when "private_ssl_certificate"
-        end
-
-      end
-
+  class Order
+    def initialize(name_id, attributes = {})
+      @name_id = name_id
+      @attributes = attributes
     end
 
+    def create
+      certificate_klass.create(attributes)
+    end
+
+    def self.create(name_id, attributes)
+      new(name_id, attributes).create
+    end
+
+    private
+
+    attr_reader :attributes
+
+    def certificate_klass
+      certificate_klass_hash[@name_id.to_sym] ||
+        Digicert::SSLCertificate::SSLPlus
+    end
+
+    def certificate_klass_hash
+      {
+        ssl_plus: Digicert::SSLCertificate::SSLPlus,
+        ssl_wildcard: Digicert::SSLCertificate::SSLWildcard,
+        ssl_ev_plus: Digicert::SSLCertificate::SSLEVPlus,
+        client_premium: Digicert::ClientCertificate::Premium,
+        email_security_plus: Digicert::ClientCertificate::EmailSecurityPlus,
+        digital_signature_plus: Digicert::ClientCertificate::DigitalSignaturePlus,
+      }
+    end
   end
 end
-
-require 'digicert/order/base'
-require 'digicert/order/ssl'
-require 'digicert/order/ev_ssl'
-require 'digicert/order/private'
-
-__END__
-

--- a/lib/digicert/ssl_certificate.rb
+++ b/lib/digicert/ssl_certificate.rb
@@ -1,8 +1,0 @@
-require "digicert/ssl_certificate/ssl_plus"
-require "digicert/ssl_certificate/ssl_ev_plus"
-require "digicert/ssl_certificate/ssl_wildcard"
-
-module Digicert
-  module SSLCertificate
-  end
-end

--- a/lib/digicert/ssl_certificate/ssl_plus.rb
+++ b/lib/digicert/ssl_certificate/ssl_plus.rb
@@ -2,7 +2,7 @@ require "digicert/base_order"
 
 module Digicert
   module SSLCertificate
-    class SSLPlus < Digicert::Order::Base
+    class SSLPlus < Digicert::BaseOrder
       private
 
       def certificate_type

--- a/spec/acceptance/certificate_download_spec.rb
+++ b/spec/acceptance/certificate_download_spec.rb
@@ -16,8 +16,7 @@ RSpec.describe "Download a certificate" do
     #
     order_attributes = build_order_attributes(product)
     stub_digicert_order_create_api("ssl_plus", order_attributes)
-    order = Digicert::SSLCertificate::SSLPlus.create(order_attributes)
-    # order = Digicert::Order::SSLPlus.create(order_attributes)
+    order = Digicert::Order.create("ssl_plus", order_attributes)
 
     # Retrieve the certificate order details with the
     # certificate id in it, so we can use this one to

--- a/spec/digicert/order_spec.rb
+++ b/spec/digicert/order_spec.rb
@@ -1,0 +1,38 @@
+require "spec_helper"
+
+RSpec.describe Digicert::Order do
+  describe ".create" do
+    it "creates a new order" do
+      name_id = "ssl_plus"
+
+      stub_digicert_order_create_api(name_id, order_attributes)
+      order = Digicert::Order.create(name_id, order_attributes)
+
+      expect(order.id).not_to be_nil
+      expect(order.requests.first.id).not_to be_nil
+      expect(order.requests.first.status).not_to be_nil
+    end
+  end
+
+  def order_attributes
+    {
+      certificate: {
+        organization_units: ["Developer Operations"],
+        server_platform: { id: 45 },
+        profile_option: "some_ssl_profile",
+
+        # Required for certificate
+        csr: "------ [CSR HERE] ------",
+        common_name: "digicert.com",
+        signature_hash: "sha256",
+      },
+      organization: { id: 117483 },
+      validity_years: 3,
+      custom_expiration_date: "2017-05-18",
+      comments: "Comments for the the approver",
+      disable_renewal_notifications: false,
+      renewal_of_order_id: 314152,
+      payment_method: "balance",
+    }
+  end
+end


### PR DESCRIPTION
This commit adds an unified interface to create a new order, now the user does not need to be worried about too much details, they can create a new order by simply passing the `name_id` and the `attributes_hash`, and our `Order` interface will do the rest.

```ruby
Digicert::Order.create(
  name_id, order_attributes_hash,
)
```

Please check the `Readme` for details usages guide.