### PR TITLE
Extract common behavior to a base

### DIFF
--- a/lib/digicert/client_certificate/base.rb
+++ b/lib/digicert/client_certificate/base.rb
@@ -1,0 +1,17 @@
+require "digicert/base_order"
+
+module Digicert
+  module ClientCertificate
+    class Base < Digicert::BaseOrder
+      private
+
+      def validate_certificate(common_name:, signature_hash:, emails:, **attrs)
+        attrs.merge(
+          emails: emails,
+          common_name: common_name,
+          signature_hash: signature_hash,
+        )
+      end
+    end
+  end
+end

--- a/lib/digicert/client_certificate/digital_signature_plus.rb
+++ b/lib/digicert/client_certificate/digital_signature_plus.rb
@@ -1,16 +1,12 @@
-require "digicert/base_order"
+require "digicert/client_certificate/base"
 
 module Digicert
   module ClientCertificate
-    class DigitalSignaturePlus < Digicert::BaseOrder
+    class DigitalSignaturePlus < Digicert::ClientCertificate::Base
       private
 
       def certificate_type
         "client_digital_signature_plus"
-      end
-
-      def validate_certificate(emails:, **attributes)
-        super(attributes.merge(emails: emails))
       end
     end
   end

--- a/lib/digicert/client_certificate/email_security_plus.rb
+++ b/lib/digicert/client_certificate/email_security_plus.rb
@@ -1,20 +1,12 @@
-require "digicert/base_order"
+require "digicert/client_certificate/base"
 
 module Digicert
   module ClientCertificate
-    class EmailSecurityPlus < Digicert::BaseOrder
+    class EmailSecurityPlus < Digicert::ClientCertificate::Base
       private
 
       def certificate_type
         "client_email_security_plus"
-      end
-
-      def validate_certificate(common_name:, signature_hash:, emails:, **attrs)
-        attrs.merge(
-          emails: emails,
-          common_name: common_name,
-          signature_hash: signature_hash,
-        )
       end
     end
   end

--- a/lib/digicert/client_certificate/premium.rb
+++ b/lib/digicert/client_certificate/premium.rb
@@ -1,16 +1,16 @@
-require "digicert/base_order"
+require "digicert/client_certificate/base"
 
 module Digicert
   module ClientCertificate
-    class Premium < Digicert::BaseOrder
+    class Premium < Digicert::ClientCertificate::Base
       private
 
       def certificate_type
         "client_premium_sha2"
       end
 
-      def validate_certificate(emails:, **attributes)
-        super(attributes.merge(emails: emails))
+      def validate_certificate(csr:, **attributes)
+        super(attributes.merge(csr: csr))
       end
     end
   end

--- a/spec/digicert/client_certificate/digital_signature_plus_spec.rb
+++ b/spec/digicert/client_certificate/digital_signature_plus_spec.rb
@@ -20,7 +20,6 @@ RSpec.describe Digicert::ClientCertificate::DigitalSignaturePlus do
       certificate: {
         # Required for certificate
         emails: ["email@example.com", "email1@example.com"],
-        csr: "-----BEGIN CERTIFICATE REQUEST----- ...",
         common_name: "Full Name",
         signature_hash: "sha256",
       },

--- a/spec/digicert/client_certificate/premium_spec.rb
+++ b/spec/digicert/client_certificate/premium_spec.rb
@@ -18,8 +18,8 @@ RSpec.describe Digicert::ClientCertificate::Premium do
         profile_option: "some_ssl_profile",
 
         # Required for certificate
-        emails: ["email@example.com", "email1@example.com"],
         csr: "------ [CSR HERE] ------",
+        emails: ["email@example.com", "email1@example.com"],
         common_name: "digicert.com",
         signature_hash: "sha256",
       },


### PR DESCRIPTION
The `client_certificate`'s were sharing some common behavior, this commit extract those behavior to a base class, and all of the `client_certificate` will inherit from this one, so we can easily put the common behavior here.