### PR TITLE
Inherit from `Digicert::SSLCertificate::Base`

### DIFF
--- a/lib/digicert/ssl_certificate/base.rb
+++ b/lib/digicert/ssl_certificate/base.rb
@@ -1,0 +1,9 @@
+require "digicert/base_order"
+
+module Digicert
+  module SSLCertificate
+    class Base < Digicert::BaseOrder
+
+    end
+  end
+end

--- a/lib/digicert/ssl_certificate/ssl_ev_plus.rb
+++ b/lib/digicert/ssl_certificate/ssl_ev_plus.rb
@@ -1,8 +1,8 @@
-require "digicert/base_order"
+require "digicert/ssl_certificate/base"
 
 module Digicert
   module SSLCertificate
-    class SSLEVPlus < Digicert::BaseOrder
+    class SSLEVPlus < Digicert::SSLCertificate::Base
       private
 
       def certificate_type

--- a/lib/digicert/ssl_certificate/ssl_plus.rb
+++ b/lib/digicert/ssl_certificate/ssl_plus.rb
@@ -1,8 +1,8 @@
-require "digicert/base_order"
+require "digicert/ssl_certificate/base"
 
 module Digicert
   module SSLCertificate
-    class SSLPlus < Digicert::BaseOrder
+    class SSLPlus < Digicert::SSLCertificate::Base
       private
 
       def certificate_type

--- a/lib/digicert/ssl_certificate/ssl_wildcard.rb
+++ b/lib/digicert/ssl_certificate/ssl_wildcard.rb
@@ -1,8 +1,8 @@
-require "digicert/base_order"
+require "digicert/ssl_certificate/base"
 
 module Digicert
   module SSLCertificate
-    class SSLWildcard < Digicert::BaseOrder
+    class SSLWildcard < Digicert::SSLCertificate::Base
       private
 
       def certificate_type


### PR DESCRIPTION
The `ssl_certificate`s were inheriting from the generic `BaseOrder` class, we don't have any edge cases now, but it is a better option to have a `Base` class on it's own, so it's not fully depended on the very generic class but the own on it's own.