### PR TITLE
Add interface to list all templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,18 @@ Digicert.configuration.api_key = "SECRET_DEV_API_KEY"
 
 ## Usage
 
+### Container
+
+#### List Container Templates
+
+Container Templates define a set of features that are available to a container.
+Use this interface to retrieve a list of the templates that are available to use
+to create child containers.
+
+```ruby
+Digicert::ContainerTemplate.all(container_id)
+```
+
 ### Product
 
 #### List Products

--- a/lib/digicert.rb
+++ b/lib/digicert.rb
@@ -13,6 +13,7 @@ require "digicert/order"
 require "digicert/certificate_request"
 require "digicert/certificate_order"
 require "digicert/organization"
+require "digicert/container_template"
 
 module Digicert
 

--- a/lib/digicert/container_template.rb
+++ b/lib/digicert/container_template.rb
@@ -1,0 +1,23 @@
+require "digicert/base"
+
+module Digicert
+  class ContainerTemplate < Base
+    def initialize(container_id)
+      @container_id = container_id
+    end
+
+    def self.all(container_id)
+      new(container_id).all
+    end
+
+    private
+
+    def resources_key
+      "container_templates"
+    end
+
+    def resource_path
+      ["container", @container_id, "template"].join("/")
+    end
+  end
+end

--- a/spec/digicert/container_template_spec.rb
+++ b/spec/digicert/container_template_spec.rb
@@ -1,0 +1,16 @@
+require "spec_helper"
+
+RSpec.describe Digicert::ContainerTemplate do
+  describe ".all" do
+    it "retrieves the list of all container tempaltes" do
+      container_id = 123_456_789
+
+      stub_digicert_container_template_list_api(container_id)
+      container_templates = Digicert::ContainerTemplate.all(container_id)
+
+      expect(container_templates.count).to eq(2)
+      expect(container_templates.first.id).not_to be_nil
+      expect(container_templates.first.name).not_to be_nil
+    end
+  end
+end

--- a/spec/fixtures/container_templates.json
+++ b/spec/fixtures/container_templates.json
@@ -1,0 +1,14 @@
+{
+  "container_templates": [
+    {
+      "id": 4,
+      "name": "College",
+      "date_created": "2014-08-05T20:11:28+00:00"
+    },
+    {
+      "id": 5,
+      "name": "Department",
+      "date_created": "2014-08-05T20:11:28+00:00"
+    }
+  ]
+}

--- a/spec/support/fake_digicert_api.rb
+++ b/spec/support/fake_digicert_api.rb
@@ -59,6 +59,15 @@ module Digicert
       )
     end
 
+    def stub_digicert_container_template_list_api(container_id)
+      stub_api_response(
+        :get,
+        ["container", container_id, "template"].join("/"),
+        filename: "container_templates",
+        status: 200,
+      )
+    end
+
     def stub_api_response(method, end_point, filename:, status: 200, data: nil)
       stub_request(method, digicert_api_end_point(end_point)).
         with(digicert_api_request_headers(data: data)).


### PR DESCRIPTION
Container Templates define a set of features that are available to a container. This commit add the interface to retrieve the list of all available container templates. To retrieve the list you need to pass the `parent_container_id` and it will return the objects

```ruby
Digicert::ContainerTemplate.all(container_id)
```