### PR TITLE
Add interface to fetch a template details

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,17 @@ to create child containers.
 Digicert::ContainerTemplate.all(container_id)
 ```
 
+#### View a Container Template
+
+Use this interface to retrieve information about a specific container template,
+including which user access roles are available under this template.
+
+```ruby
+Digicert::ContainerTemplate.fetch(
+  template_id: template_id, container_id: container_id,
+)
+```
+
 ### Product
 
 #### List Products

--- a/lib/digicert/container_template.rb
+++ b/lib/digicert/container_template.rb
@@ -2,12 +2,17 @@ require "digicert/base"
 
 module Digicert
   class ContainerTemplate < Base
-    def initialize(container_id)
+    def initialize(container_id:, resource_id: nil)
+      @resource_id = resource_id
       @container_id = container_id
     end
 
     def self.all(container_id)
-      new(container_id).all
+      new(container_id: container_id).all
+    end
+
+    def self.fetch(template_id:, container_id:)
+      new(resource_id: template_id, container_id: container_id).fetch
     end
 
     private

--- a/spec/digicert/container_template_spec.rb
+++ b/spec/digicert/container_template_spec.rb
@@ -13,4 +13,20 @@ RSpec.describe Digicert::ContainerTemplate do
       expect(container_templates.first.name).not_to be_nil
     end
   end
+
+  describe ".fetch" do
+    it "retrieves the specific container tempalte" do
+      template_id = 987_654_321
+      container_id = 123_456_789
+      stub_digicert_container_template_fetch_api(template_id, container_id)
+
+      container_template = Digicert::ContainerTemplate.fetch(
+        container_id: container_id, template_id: template_id,
+      )
+
+      expect(container_template.id).not_to be_nil
+      expect(container_template.name).not_to be_nil
+      expect(container_template.access_roles.first.name).to eq("Administrator")
+    end
+  end
 end

--- a/spec/fixtures/container_template.json
+++ b/spec/fixtures/container_template.json
@@ -1,0 +1,15 @@
+{
+  "id": 4,
+  "name": "University Department",
+  "date_created": "2014-08-05T20:11:28+00:00",
+  "access_roles": [
+    {
+      "id": 1,
+      "name": "Administrator"
+    },
+    {
+      "id": 2,
+      "name": "User"
+    }
+  ]
+}

--- a/spec/support/fake_digicert_api.rb
+++ b/spec/support/fake_digicert_api.rb
@@ -68,6 +68,15 @@ module Digicert
       )
     end
 
+    def stub_digicert_container_template_fetch_api(template_id, container_id)
+      stub_api_response(
+        :get,
+        ["container", container_id, "template", template_id].join("/"),
+        filename: "container_template",
+        status: 200,
+      )
+    end
+
     def stub_api_response(method, end_point, filename:, status: 200, data: nil)
       stub_request(method, digicert_api_end_point(end_point)).
         with(digicert_api_request_headers(data: data)).


### PR DESCRIPTION
This commit adds the interface to fetch a specific template details, The way Digicert works is, we need provide the `template_id`, along with `container_id` to retrieve the details for a template.

This commit adds the interface that override the default `fetch` method signature, and now it expects two keys that is required to specify the `container_id` and `template_id`, and as being a hash arguments we don't need to provide those arguments in any specific order. Usages

```ruby
Digicert::ContainerTemplate.fetch(
  container_id: container_id, template_id: template_id,
)
```