### PR TITLE
Add interface to fetch a container

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,15 @@ Digicert::Container.create(
 )
 ```
 
+#### View a Container
+
+Information about a specific container can be retrieved through this interface,
+including its name, description, template, and parent container id.
+
+```ruby
+Digicert::Container.fetch(container_id)
+```
+
 ### Product
 
 #### List Products

--- a/lib/digicert/container.rb
+++ b/lib/digicert/container.rb
@@ -2,8 +2,9 @@ require "digicert/base"
 
 module Digicert
   class Container < Digicert::Base
-    def initialize(container_id)
-      @container_id = container_id
+    def initialize(attributes = {})
+      @resource_id = attributes[:resource_id]
+      @container_id = attributes[:container_id]
     end
 
     def create(name:, template_id:, **attributes)
@@ -15,7 +16,7 @@ module Digicert
     end
 
     def self.create(container_id:, **attributes)
-      new(container_id).create(attributes)
+      new(container_id: container_id).create(attributes)
     end
 
     private

--- a/spec/digicert/container_spec.rb
+++ b/spec/digicert/container_spec.rb
@@ -10,6 +10,19 @@ RSpec.describe Digicert::Container do
     end
   end
 
+  describe ".fetch" do
+    it "retrieves the details for a container" do
+      container_id = 123_456_789
+
+      stub_digicert_container_fetch_api(container_id)
+      container = Digicert::Container.fetch(container_id)
+
+      expect(container.name).not_to be_nil
+      expect(container.parent_id).not_to be_nil
+      expect(container.allowed_domain_names.first).to eq("abc.xyz")
+    end
+  end
+
   def container_attributes
     {
       container_id: 123_456_789,

--- a/spec/fixtures/container.json
+++ b/spec/fixtures/container.json
@@ -1,0 +1,15 @@
+{
+  "id": 3,
+  "public_id": "c3f355cae8eb30b8d77b7b282686f0c",
+  "name": "Heidelberg University",
+  "description": "Germany University of Heidelberg",
+  "parent_id": 2,
+  "template_id": 3,
+  "ekey": "BR549",
+  "has_logo": false,
+  "is_active": true,
+  "allowed_domain_names": [
+    "abc.xyz",
+    "digicert.com"
+  ]
+}

--- a/spec/support/fake_digicert_api.rb
+++ b/spec/support/fake_digicert_api.rb
@@ -87,6 +87,12 @@ module Digicert
       )
     end
 
+    def stub_digicert_container_fetch_api(container_id)
+      stub_api_response(
+        :get, ["container", container_id].join("/"), filename: "container",
+      )
+    end
+
     def stub_api_response(method, end_point, filename:, status: 200, data: nil)
       stub_request(method, digicert_api_end_point(end_point)).
         with(digicert_api_request_headers(data: data)).


### PR DESCRIPTION
This commit adds the interface to fetch a container details, including its name, description, template, and parent container id and Usages is as simple as

```ruby
Digicert::Container.fetch(container_id)
```