### PR TITLE
Add interface to fetch an organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,14 @@ organization_attributes = {
 }
 ```
 
+#### View an Organization
+
+Use this interface to view information about an organization.
+
+```ruby
+Digicert::Organization.fetch(organization_id)
+```
+
 ## Play Box
 
 The API Play Box provides an interactive console so we can easily test out the

--- a/spec/digicert/organization_spec.rb
+++ b/spec/digicert/organization_spec.rb
@@ -22,6 +22,19 @@ RSpec.describe Digicert::Organization do
     end
   end
 
+  describe ".fetch" do
+    it "retrieves the specified organization details" do
+      organization_id = 123_456_789
+
+      stub_digicert_organization_fetch_api(organization_id)
+      organization = Digicert::Organization.fetch(organization_id)
+
+      expect(organization.id).not_to be_nil
+      expect(organization.name).not_to be_nil
+      expect(organization.container.id).not_to be_nil
+    end
+  end
+
   def organization_attributes
     {
       name: "digicert, inc.",

--- a/spec/fixtures/organization.json
+++ b/spec/fixtures/organization.json
@@ -1,0 +1,35 @@
+{
+  "id": 117483,
+  "status": "approved",
+  "name": "DigiCert, Inc.",
+  "assumed_name": "DigiCert",
+  "display_name": "DigiCert",
+  "is_active": true,
+  "address": "333 S 520 W",
+  "address2": "Suite 500",
+  "zip": "84042",
+  "city": "Lindon",
+  "state": "Utah",
+  "country": "US",
+  "telephone": "801-555-0246",
+  "container": {
+    "id": 1,
+    "name": "Parent Company",
+    "is_active": true
+  },
+  "organization_contact": {
+    "id": 376032,
+    "first_name": "Some",
+    "last_name": "Guy",
+    "email": "someguy@digicert.com",
+    "telephone": "8017050481",
+    "telephone_extension": "5"
+  },
+  "ev_approvers": [
+    {
+      "id": 1500432,
+      "first_name": "John",
+      "last_name": "Smith"
+    }
+  ]
+}

--- a/spec/support/fake_digicert_api.rb
+++ b/spec/support/fake_digicert_api.rb
@@ -69,6 +69,12 @@ module Digicert
       )
     end
 
+    def stub_digicert_organization_fetch_api(id)
+      stub_api_response(
+        :get, ["organization", id].join("/"), filename: "organization",
+      )
+    end
+
     def stub_digicert_container_template_list_api(container_id)
       stub_api_response(
         :get,


### PR DESCRIPTION
This commit adds the interface to fetch the details for a specified organization, including parent container and approval status, Usage

```ruby
Digicert::Organization.fetch(organization_id)
```