### PR TITLE
Add interface to retrieve all domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,6 +423,16 @@ domain_attributes = {
 }
 ```
 
+#### List Domains
+
+Use this interface to retrieve a list of domains. This interface also supports
+an additional `filter_params` hash, which can be used to filter the list we want
+the interface to return.
+
+```ruby
+Digicert::Domain.all(filter_params_hash)
+```
+
 ## Play Box
 
 The API Play Box provides an interactive console so we can easily test out the

--- a/lib/digicert/actions/all.rb
+++ b/lib/digicert/actions/all.rb
@@ -6,13 +6,16 @@ module Digicert
       extend Digicert::Actions::Base
 
       def all
-        response = Digicert::Request.new(:get, resource_path).run
+        response = Digicert::Request.new(
+          :get, resource_path, params: params,
+        ).run
+
         response[resources_key]
       end
 
       module ClassMethods
-        def all
-          new.all
+        def all(filter_params = {})
+          new(params: filter_params).all
         end
       end
     end

--- a/lib/digicert/base.rb
+++ b/lib/digicert/base.rb
@@ -9,12 +9,13 @@ module Digicert
 
     def initialize(attributes = {})
       @attributes = attributes
+      @params = @attributes.delete(:params)
       @resource_id = @attributes.delete(:resource_id)
     end
 
     private
 
-    attr_reader :attributes, :resource_id
+    attr_reader :attributes, :resource_id, :params
 
     def resources_key
       [resource_path, "s"].join

--- a/lib/digicert/request.rb
+++ b/lib/digicert/request.rb
@@ -5,10 +5,11 @@ require "digicert/response"
 
 module Digicert
   class Request
-    def initialize(http_method, end_point, attributes = {})
+    def initialize(http_method, end_point, params: {}, **attributes)
       @end_point = end_point
       @http_method = http_method
       @attributes = attributes
+      @query_params = params
     end
 
     def run
@@ -36,6 +37,7 @@ module Digicert
       URI::HTTPS.build(
         host: Digicert.configuration.api_host,
         path: digicert_api_path_with_base,
+        query: build_query_params,
       )
     end
 
@@ -54,6 +56,12 @@ module Digicert
       request.initialize_http_header(
         "X-DC-DEVKEY" => Digicert.configuration.api_key,
       )
+    end
+
+    def build_query_params
+      if @query_params
+        URI.encode_www_form(@query_params)
+      end
     end
 
     def digicert_api_path_with_base

--- a/spec/digicert/domain_spec.rb
+++ b/spec/digicert/domain_spec.rb
@@ -10,6 +10,31 @@ RSpec.describe Digicert::Domain do
     end
   end
 
+  describe ".all" do
+    context "without any filters" do
+      it "retrieves the list of domains" do
+        stub_digicert_domain_list_api
+        domains = Digicert::Domain.all
+
+        expect(domains.count).to eq(2)
+        expect(domains.first.id).not_to be_nil
+        expect(domains.first.name).not_to be_nil
+      end
+    end
+
+    context "with custom filters" do
+      it "retrieves the filtered list" do
+        filter_params = { container_id: 123 }
+        stub_digicert_domain_list_api(filter_params)
+        domains = Digicert::Domain.all(filter_params)
+
+        expect(domains.count).to eq(2)
+        expect(domains.first.id).not_to be_nil
+        expect(domains.first.name).not_to be_nil
+      end
+    end
+  end
+
   def domain_attributes
     {
       name: "digicert.com",

--- a/spec/fixtures/domains.json
+++ b/spec/fixtures/domains.json
@@ -1,0 +1,49 @@
+{
+  "domains": [
+    {
+      "id": 1,
+      "name": "digicert.com",
+      "date_created": "2013-10-17T22:27:42+00:00",
+      "organization": {
+        "id": 117483,
+        "name": "DigiCert, Inc.",
+        "assumed_name": "Assumed Name Example",
+        "display_name": "DigiCert, Inc. (Assumed Name Example)"
+      },
+      "validations": [
+        {
+          "type": "ov",
+          "name": "OV",
+          "description": "Normal Organization Validation",
+          "status": "pending"
+        },
+        {
+          "type": "ev",
+          "name": "EV",
+          "description": "Extended Organization Validation (EV)",
+          "status": "pending"
+        }
+      ],
+      "container": {
+        "id": 3,
+        "name": "Heidelberg University"
+      }
+    },
+    {
+      "id": 2,
+      "name": "testing.com",
+      "date_created": "2013-10-17T22:27:42+00:00",
+      "organization": {
+        "id": 117483,
+        "name": "DigiCert, Inc.",
+        "assumed_name": "Assumed Name Example",
+        "display_name": "DigiCert, Inc. (Assumed Name Example)"
+      },
+      "container": {
+        "id": 3,
+        "name": "Heidelberg University"
+      }
+    }
+  ]
+}
+

--- a/spec/support/fake_digicert_api.rb
+++ b/spec/support/fake_digicert_api.rb
@@ -119,6 +119,14 @@ module Digicert
       )
     end
 
+    def stub_digicert_domain_list_api(filters = {})
+      params = filters.map { |key, value| "#{key}=#{value}" }.join("&")
+
+      stub_api_response(
+        :get, ["domain", params].join("?"), filename: "domains", status: 200,
+      )
+    end
+
     def stub_api_response(method, end_point, filename:, status: 200, data: nil)
       stub_request(method, digicert_api_end_point(end_point)).
         with(digicert_api_request_headers(data: data)).


### PR DESCRIPTION
This commit implements the interface to retrieve the list of all domains using the Digicert Domain API. This interface also supports one additional hash argument to filter the results we want from the API.

This commit also change the existing `Digicert::Request`, so it supports an additional `params` key, which we can use to pass the query params along with the request.

```ruby
Digicert::Domain.all(filters_params)
```