### PR TITLE
Add interface to retrieve a domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,6 +433,16 @@ the interface to return.
 Digicert::Domain.all(filter_params_hash)
 ```
 
+#### View a Domain
+
+Use this interface to view a domain, This interface also allows you to pass an
+additional to `hash` to specify if you want to retrieve additional data with the
+response.
+
+```ruby
+Digicert::Domain.fetch(domain_id, include_dcv: true)
+```
+
 ## Play Box
 
 The API Play Box provides an interactive console so we can easily test out the

--- a/lib/digicert/actions/all.rb
+++ b/lib/digicert/actions/all.rb
@@ -7,7 +7,7 @@ module Digicert
 
       def all
         response = Digicert::Request.new(
-          :get, resource_path, params: params,
+          :get, resource_path, params: query_params,
         ).run
 
         response[resources_key]

--- a/lib/digicert/actions/fetch.rb
+++ b/lib/digicert/actions/fetch.rb
@@ -7,13 +7,13 @@ module Digicert
 
       def fetch
         Digicert::Request.new(
-          :get, [resource_path, resource_id].join("/"),
+          :get, [resource_path, resource_id].join("/"), params: query_params,
         ).run
       end
 
       module ClassMethods
-        def fetch(resource_id)
-          new(resource_id: resource_id).fetch
+        def fetch(resource_id, filter_params = {})
+          new(resource_id: resource_id, params: filter_params).fetch
         end
       end
     end

--- a/lib/digicert/base.rb
+++ b/lib/digicert/base.rb
@@ -9,13 +9,13 @@ module Digicert
 
     def initialize(attributes = {})
       @attributes = attributes
-      @params = @attributes.delete(:params)
+      @query_params = @attributes.delete(:params)
       @resource_id = @attributes.delete(:resource_id)
     end
 
     private
 
-    attr_reader :attributes, :resource_id, :params
+    attr_reader :attributes, :resource_id, :query_params
 
     def resources_key
       [resource_path, "s"].join

--- a/spec/digicert/domain_spec.rb
+++ b/spec/digicert/domain_spec.rb
@@ -35,6 +35,20 @@ RSpec.describe Digicert::Domain do
     end
   end
 
+  describe ".fetch" do
+    it "retrieves the specific domain" do
+      domain_id = 123_456_789
+      filters = { include_dcv: true, include_validation: true}
+
+      stub_digicert_domain_fetch_api(domain_id, filters)
+      domain = Digicert::Domain.fetch(domain_id, filters)
+
+      expect(domain.id).not_to be_nil
+      expect(domain.dcv.name_scope).not_to be_nil
+      expect(domain.validations.first.type).to eq("ev")
+    end
+  end
+
   def domain_attributes
     {
       name: "digicert.com",

--- a/spec/fixtures/domain.json
+++ b/spec/fixtures/domain.json
@@ -1,0 +1,71 @@
+{
+  "id": 1,
+  "is_active": true,
+  "name": "digicert.com",
+  "date_created": "2013-10-17T22:27:42+00:00",
+  "organization": {
+    "id": 117483,
+    "status": "active",
+    "name": "DigiCert, Inc.",
+    "assumed_name": "DigiCert, Inc.",
+    "display_name": "DigiCert, Inc.",
+    "is_active": true
+  },
+  "validations": [
+    {
+      "type": "ev",
+      "name": "EV",
+      "description": "Extended Organization Validation (EV)",
+      "date_created": "2014-08-09T17:04:59+00:00",
+      "validated_until": "2015-08-09T17:04:45+00:00",
+      "status": "active",
+      "dcv_status": "complete",
+      "verified_users": [
+        {
+          "id": 1234,
+          "first_name": "Jane",
+          "last_name": "Doe"
+        }
+      ]
+    },
+    {
+      "type": "ov",
+      "name": "OV",
+      "description": "Normal Organization Validation",
+      "status": "pending",
+      "dcv_status": "pending"
+    }
+  ],
+  "dcv": {
+    "method": "email",
+    "name_scope": "digicert.com",
+    "dcv_invitations": [
+      {
+        "invitation_id": 1,
+        "email": "postmaster@digicert.com",
+        "source": "base",
+        "date_sent": "2014-08-09T17:04:59+00:00",
+        "name_scope": "digicert.com"
+      },
+      {
+        "invitation_id": 2,
+        "email": "webmaster@digicert.com",
+        "source": "base",
+        "date_sent": "2014-08-09T17:04:59+00:00",
+        "name_scope": "digicert.com"
+      },
+      {
+        "invitation_id": 3,
+        "email": "janedoe@digicert.com",
+        "source": "whois",
+        "date_sent": "2014-08-09T17:04:59+00:00",
+        "name_scope": "digicert.com"
+      }
+    ]
+  },
+  "container": {
+    "id": 3,
+    "name": "Heidelberg University",
+    "is_active": true
+  }
+}

--- a/spec/support/fake_digicert_api.rb
+++ b/spec/support/fake_digicert_api.rb
@@ -120,10 +120,17 @@ module Digicert
     end
 
     def stub_digicert_domain_list_api(filters = {})
-      params = filters.map { |key, value| "#{key}=#{value}" }.join("&")
-
       stub_api_response(
-        :get, ["domain", params].join("?"), filename: "domains", status: 200,
+        :get, path_with_query("domain", filters), filename: "domains",
+      )
+    end
+
+    def stub_digicert_domain_fetch_api(domain_id, filters)
+      stub_api_response(
+        :get,
+        path_with_query(["domain", domain_id].join("/"), filters),
+        filename: "domain",
+        status: 200,
       )
     end
 
@@ -137,6 +144,11 @@ module Digicert
 
     def digicert_api_end_point(end_point)
       ["https://www.digicert.com/services/v2", end_point].join("/")
+    end
+
+    def path_with_query(path, params)
+      query_params = params.map { |key, value| "#{key}=#{value}" }.join("&")
+      [path, query_params].join("?")
     end
 
     def digicert_api_request_headers(data: nil)


### PR DESCRIPTION
This commit adds the interface to retrieve the details for a specific domains, and it also supports one additional `hash`, so developer can specify if they want to retrieve some additional information with the response object.

```ruby
Digicert::Domain.fetch(domain_id, include_dcv: true)
```