### PR TITLE
Add interface to activate a domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,6 +443,15 @@ response.
 Digicert::Domain.fetch(domain_id, include_dcv: true)
 ```
 
+#### Activate a Domain
+
+Use this interface to activate a domain that was previously deactivated.
+
+```ruby
+domain = Digicert::Domain.find(domain_id)
+domain.activate
+```
+
 ## Play Box
 
 The API Play Box provides an interactive console so we can easily test out the

--- a/lib/digicert/domain.rb
+++ b/lib/digicert/domain.rb
@@ -5,6 +5,31 @@ module Digicert
   class Domain < Digicert::Base
     include Digicert::Actions::Create
 
+    def activate
+      Digicert::Request.new(
+        :put, [resource_path, resource_id, "activate"].join("/"),
+      ).run
+    end
+
+    # The `.find` interface is just an alternvatie to instantiate
+    # a new object, and please remeber this does not perform any
+    # actual API Request. Use this interface whenever you need to
+    # instantite an object from an existing id and then perform
+    # some operation throught the objec's instnace methods, like
+    # `#active` and `#deactivate`.
+    #
+    # If you need an actual API response then use the `.fetch`
+    # API, that will perform an actual API Reqeust and will return
+    # the response from the Digicer API.
+    #
+    # We are not going to implement this right away, but in long
+    # run may be we cna add some sort to lazy evaluation on this
+    # interface, but that's not for sure.
+    #
+    def self.find(domain_id)
+      new(resource_id: domain_id)
+    end
+
     private
 
     def resource_path

--- a/lib/digicert/response.rb
+++ b/lib/digicert/response.rb
@@ -8,7 +8,17 @@ module Digicert
     end
 
     def parse
-      JSON.parse(@response.body || "{}", object_class: ResponseObject)
+      parse_response || response
+    end
+
+    private
+
+    attr_reader :response
+
+    def parse_response
+      if response.body
+        JSON.parse(response.body, object_class: ResponseObject)
+      end
     end
   end
 

--- a/spec/digicert/certificate_request_spec.rb
+++ b/spec/digicert/certificate_request_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Digicert::CertificateRequest do
         request_id, request_status_attributes,
       )
 
-      expect(status_update.class).to eq(Digicert::ResponseObject)
+      expect(status_update.code).to eq("204")
     end
   end
 

--- a/spec/digicert/domain_spec.rb
+++ b/spec/digicert/domain_spec.rb
@@ -49,6 +49,18 @@ RSpec.describe Digicert::Domain do
     end
   end
 
+  describe "#activate" do
+    it "activates a specific domain" do
+      domain_id = 123_456_789
+      domain = Digicert::Domain.find(domain_id)
+
+      stub_digicert_domain_activate_api(domain_id)
+      domain_activation = domain.activate
+
+      expect(domain_activation.code).to eq("204")
+    end
+  end
+
   def domain_attributes
     {
       name: "digicert.com",

--- a/spec/support/fake_digicert_api.rb
+++ b/spec/support/fake_digicert_api.rb
@@ -134,6 +134,15 @@ module Digicert
       )
     end
 
+    def stub_digicert_domain_activate_api(domain_id)
+      stub_api_response(
+        :put,
+        ["domain", domain_id, "activate"].join("/"),
+        filename: "empty",
+        status: 204,
+      )
+    end
+
     def stub_api_response(method, end_point, filename:, status: 200, data: nil)
       stub_request(method, digicert_api_end_point(end_point)).
         with(digicert_api_request_headers(data: data)).


### PR DESCRIPTION
This commit adds the interface to activate a `domain` using the Digicert Domain Activation API. This commit also adds a `.find` interface to instantiate a new object and it also changes the existing `Digicert::Response` parsing.

```ruby
domain = Digicert::Domain.find(domain_id)
domain.activate
```