### PR TITLE
Add interface to deactivate a domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,6 +452,15 @@ domain = Digicert::Domain.find(domain_id)
 domain.activate
 ```
 
+#### Deactivate a Domain
+
+Use this interface to deactivate a domain.
+
+```ruby
+domain = Digicert::Domain.find(domain_id)
+domain.deactivate
+```
+
 ## Play Box
 
 The API Play Box provides an interactive console so we can easily test out the

--- a/lib/digicert/domain.rb
+++ b/lib/digicert/domain.rb
@@ -11,6 +11,12 @@ module Digicert
       ).run
     end
 
+    def deactivate
+      Digicert::Request.new(
+        :put, [resource_path, resource_id, "deactivate"].join("/"),
+      ).run
+    end
+
     # The `.find` interface is just an alternvatie to instantiate
     # a new object, and please remeber this does not perform any
     # actual API Request. Use this interface whenever you need to

--- a/spec/digicert/domain_spec.rb
+++ b/spec/digicert/domain_spec.rb
@@ -61,6 +61,18 @@ RSpec.describe Digicert::Domain do
     end
   end
 
+  describe "#deactivate" do
+    it "deactivates a specific domain" do
+      domain_id = 123_456_789
+      domain = Digicert::Domain.find(domain_id)
+
+      stub_digicert_domain_deactivate_api(domain_id)
+      domain_deactivation = domain.deactivate
+
+      expect(domain_deactivation.code).to eq("204")
+    end
+  end
+
   def domain_attributes
     {
       name: "digicert.com",

--- a/spec/support/fake_digicert_api.rb
+++ b/spec/support/fake_digicert_api.rb
@@ -143,6 +143,15 @@ module Digicert
       )
     end
 
+    def stub_digicert_domain_deactivate_api(domain_id)
+      stub_api_response(
+        :put,
+        ["domain", domain_id, "deactivate"].join("/"),
+        filename: "empty",
+        status: 204,
+      )
+    end
+
     def stub_api_response(method, end_point, filename:, status: 200, data: nil)
       stub_request(method, digicert_api_end_point(end_point)).
         with(digicert_api_request_headers(data: data)).


### PR DESCRIPTION
This commit adds the interface to deactivate a domain using the Digicert Domain Management API. Usages

```ruby
Digicert::Domain.find(domain_id).deactivate
```