### PR TITLE
Add interface to retrieve an order

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,15 @@ The supported `name_id`'s are `ssl_plus`, `ssl_wildcard`, `ssl_ev_plus`,
 `client_premium`, `email_security_plus` and `digital_signature_plus`. Please
 check the Digicert documentation for more details on those.
 
+#### View a Certificate Order
+
+Use this interface to retrieve a certificate order and the response includes all
+the order attributes along with a `certificate` in it.
+
+```ruby
+Digicert::Order.fetch(order_id)
+```
+
 #### Order SSL Plus Certificate
 
 Use this interface to order a SSL Plus Certificate.

--- a/lib/digicert/order.rb
+++ b/lib/digicert/order.rb
@@ -3,6 +3,7 @@
 #
 #
 
+require "digicert/base"
 require "digicert/ssl_certificate/ssl_plus"
 require "digicert/ssl_certificate/ssl_ev_plus"
 require "digicert/ssl_certificate/ssl_wildcard"
@@ -12,10 +13,10 @@ require "digicert/client_certificate/email_security_plus"
 require "digicert/client_certificate/digital_signature_plus"
 
 module Digicert
-  class Order
-    def initialize(name_id, attributes = {})
-      @name_id = name_id
-      @attributes = attributes
+  class Order < Digicert::Base
+    def initialize(attributes = {})
+      @name_id = attributes.delete(:name_id)
+      super
     end
 
     def create
@@ -23,12 +24,14 @@ module Digicert
     end
 
     def self.create(name_id, attributes)
-      new(name_id, attributes).create
+      new(name_id: name_id, **attributes).create
     end
 
     private
 
-    attr_reader :attributes
+    def resource_path
+      "order/certificate"
+    end
 
     def certificate_klass
       certificate_klass_hash[@name_id.to_sym] ||

--- a/spec/digicert/order_spec.rb
+++ b/spec/digicert/order_spec.rb
@@ -14,6 +14,19 @@ RSpec.describe Digicert::Order do
     end
   end
 
+  describe ".fetch" do
+    it "retrieves a specific certificate order" do
+      order_id = 123_456_789
+
+      stub_digicert_order_fetch_api(order_id)
+      order = Digicert::Order.fetch(order_id)
+
+      expect(order.id).not_to be_nil
+      expect(order.status).to eq("approved")
+      expect(order.certificate.common_name).to eq("digicert.com")
+    end
+  end
+
   def order_attributes
     {
       certificate: {

--- a/spec/support/fake_digicert_api.rb
+++ b/spec/support/fake_digicert_api.rb
@@ -47,6 +47,12 @@ module Digicert
       )
     end
 
+    def stub_digicert_order_fetch_api(order_id)
+      stub_api_response(
+        :get, ["order/certificate", order_id].join("/"), filename: "order",
+      )
+    end
+
     def stub_digicert_certificate_order_fetch_api(order_id)
       stub_api_response(
         :get, ["order/certificate", order_id].join("/"), filename: "order",


### PR DESCRIPTION
This commit adds the interface to retrieve a certificate order using the Digicert Order Management API. This also updates the existing initialization method to simplify it as all the others resource classes. Usages

```ruby
Digicert::Order.fetch(order_id)
```