### PR TITLE
Add interface to list all orders

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,14 @@ the order attributes along with a `certificate` in it.
 Digicert::Order.fetch(order_id)
 ```
 
+#### List Certificate Orders
+
+Use this interface to retrieve a list of all certificate orders.
+
+```ruby
+Digicert::Order.all
+```
+
 #### Order SSL Plus Certificate
 
 Use this interface to order a SSL Plus Certificate.

--- a/lib/digicert/order.rb
+++ b/lib/digicert/order.rb
@@ -33,6 +33,10 @@ module Digicert
       "order/certificate"
     end
 
+    def resources_key
+      "orders"
+    end
+
     def certificate_klass
       certificate_klass_hash[@name_id.to_sym] ||
         Digicert::SSLCertificate::SSLPlus

--- a/spec/digicert/order_spec.rb
+++ b/spec/digicert/order_spec.rb
@@ -27,6 +27,17 @@ RSpec.describe Digicert::Order do
     end
   end
 
+  describe ".all" do
+    it "retrieves the list of all certificate orders" do
+      stub_digicert_order_list_api
+      orders = Digicert::Order.all
+
+      expect(orders.first.id).not_to be_nil
+      expect(orders.first.status).to eq("issued")
+      expect(orders.first.certificate.common_name).to eq("digicert.com")
+    end
+  end
+
   def order_attributes
     {
       certificate: {

--- a/spec/fixtures/orders.json
+++ b/spec/fixtures/orders.json
@@ -1,0 +1,93 @@
+{
+  "orders": [
+    {
+      "id": 556729,
+      "certificate": {
+        "common_name": "digicert.com",
+        "dns_names": [
+          "digicert.com",
+          "www.digicert.com"
+        ],
+        "valid_till": "2017-08-19",
+        "signature_hash": "sha256"
+      },
+      "status": "issued",
+      "date_created": "2014-08-19T18:16:07+00:00",
+      "organization": {
+        "id": 117483,
+        "name": "DigiCert, Inc."
+      },
+      "validity_years": 3,
+      "container": {
+        "id": 5,
+        "name": "College of Science"
+      },
+      "product": {
+        "name_id": "ssl_plus",
+        "name": "SSL Plus",
+        "type": "ssl_certificate"
+      },
+      "price": 293
+    },
+    {
+      "id": 556730,
+      "certificate": {
+        "common_name": "digicert.com",
+        "dns_names": [
+          "digicert.com",
+          "www.digicert.com"
+        ],
+        "valid_till": "2017-08-19",
+        "signature_hash": "sha256"
+      },
+      "status": "needs_approval",
+      "date_created": "2014-08-20T17:20:59+00:00",
+      "organization": {
+        "id": 117483,
+        "name": "DigiCert, Inc."
+      },
+      "validity_years": 3,
+      "container": {
+        "id": 5,
+        "name": "College of Science"
+      },
+      "product": {
+        "name_id": "ssl_plus",
+        "name": "SSL Plus",
+        "type": "ssl_certificate"
+      }
+    },
+    {
+      "id": 556731,
+      "certificate": {
+        "common_name": "digicert.com",
+        "dns_names": [
+          "digicert.com",
+          "www.digicert.com"
+        ],
+        "signature_hash": "SHA256"
+      },
+      "status": "needs_approval",
+      "date_created": "2014-08-20T17:20:59+00:00",
+      "organization": {
+        "id": 117483,
+        "name": "DigiCert, Inc."
+      },
+      "validity_years": 3,
+      "container": {
+        "id": 5,
+        "name": "College of Science"
+      },
+      "product": {
+        "name_id": "ssl_plus",
+        "name": "SSL Plus",
+        "type": "ssl_certificate"
+      }
+    }
+  ],
+  "page": {
+    "total": 1,
+    "limit": 1000,
+    "offset": 0
+  }
+}

--- a/spec/support/fake_digicert_api.rb
+++ b/spec/support/fake_digicert_api.rb
@@ -53,6 +53,12 @@ module Digicert
       )
     end
 
+    def stub_digicert_order_list_api
+      stub_api_response(
+        :get, "order/certificate", filename: "orders", status: 200,
+      )
+    end
+
     def stub_digicert_certificate_order_fetch_api(order_id)
       stub_api_response(
         :get, ["order/certificate", order_id].join("/"), filename: "order",


### PR DESCRIPTION
This commit adds the interface to list all orders using the Digicert Order Management API. Usages

```ruby
Digicert::Order.all
```