### PR TITLE
Add `#parse` to `Digicert::Request`

### DIFF
--- a/lib/digicert/actions/all.rb
+++ b/lib/digicert/actions/all.rb
@@ -8,7 +8,7 @@ module Digicert
       def all
         response = Digicert::Request.new(
           :get, resource_path, params: query_params,
-        ).run
+        ).parse
 
         response[resources_key]
       end

--- a/lib/digicert/actions/create.rb
+++ b/lib/digicert/actions/create.rb
@@ -8,7 +8,7 @@ module Digicert
       def create
         Digicert::Request.new(
           :post, resource_creation_path || resource_path, validate(attributes),
-        ).run
+        ).parse
       end
 
       module ClassMethods

--- a/lib/digicert/actions/fetch.rb
+++ b/lib/digicert/actions/fetch.rb
@@ -8,7 +8,7 @@ module Digicert
       def fetch
         Digicert::Request.new(
           :get, [resource_path, resource_id].join("/"), params: query_params,
-        ).run
+        ).parse
       end
 
       module ClassMethods

--- a/lib/digicert/certificate_request.rb
+++ b/lib/digicert/certificate_request.rb
@@ -6,7 +6,7 @@ module Digicert
     def update
       Digicert::Request.new(
         :put, update_status_path, attributes,
-      ).run
+      ).parse
     end
 
     def self.update(resource_id, attributes)

--- a/lib/digicert/domain.rb
+++ b/lib/digicert/domain.rb
@@ -8,13 +8,13 @@ module Digicert
     def activate
       Digicert::Request.new(
         :put, [resource_path, resource_id, "activate"].join("/"),
-      ).run
+      ).parse
     end
 
     def deactivate
       Digicert::Request.new(
         :put, [resource_path, resource_id, "deactivate"].join("/"),
-      ).run
+      ).parse
     end
 
     # The `.find` interface is just an alternvatie to instantiate

--- a/lib/digicert/request.rb
+++ b/lib/digicert/request.rb
@@ -13,7 +13,11 @@ module Digicert
     end
 
     def run
-      Response.new(send_http_request).parse
+      send_http_request
+    end
+
+    def parse
+      Digicert::Response.new(run).parse
     end
 
     private

--- a/spec/digicert/request_spec.rb
+++ b/spec/digicert/request_spec.rb
@@ -7,6 +7,16 @@ RSpec.describe Digicert::Request do
       stub_ping_reqeust_via_get
       response = Digicert::Request.new(:get, "ping").run
 
+      expect(response.code.to_i).to eq(200)
+      expect(response.class).to eq(Net::HTTPOK)
+    end
+  end
+
+  describe "#parse" do
+    it "retrives and parse the resource to object" do
+      stub_ping_reqeust_via_get
+      response = Digicert::Request.new(:get, "ping").parse
+
       expect(response.data).to eq("Pong!")
     end
   end


### PR DESCRIPTION
The existing interface for `Digicert::Request` might creates some confusion, as we have a method name `#run` and that is actually running the request and at the same time it is also parsing the response, which is bit confusing.

This commit rename it to `#parse` and add one additional `#run` method, which will only run the API request without doing any parsing. So if we do not need to parse the response then we can use the `#run` but if we do then we can use `#parse`.