### PR TITLE
Download a certificate by a platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -498,6 +498,17 @@ certificate = Digicert::CertificateDownloader.fetch(certificate_id)
 File.write("path_to_file_system/certificate.zip", certificate.body)
 ```
 
+#### Download a Certificate By Platform
+
+This interface will return an SSL Certificate file from an order using the
+platform specified.
+
+```ruby
+certificate = Digicert::CertificateDownloader.fetch_by_platform(
+  certificate_id, platform: "apache",
+)
+```
+
 ## Play Box
 
 The API Play Box provides an interactive console so we can easily test out the

--- a/lib/digicert/certificate_downloader.rb
+++ b/lib/digicert/certificate_downloader.rb
@@ -2,18 +2,39 @@ require "digicert/base"
 
 module Digicert
   class CertificateDownloader < Digicert::Base
+    def initialize(attributes = {})
+      @platform = attributes.delete(:platform)
+      super
+    end
+
     def fetch
-      Digicert::Request.new(:get, download_by_platfrom_path).run
+      Digicert::Request.new(:get, certificate_download_path).run
+    end
+
+    def self.fetch_by_platform(certificate_id, platform:)
+      new(resource_id: certificate_id, platform: platform).fetch
     end
 
     private
 
-    def download_by_platfrom_path
-      [resource_path, "platform"].join("/")
-    end
+    attr_reader :platform
 
     def resource_path
       ["certificate", resource_id, "download"].join("/")
+    end
+
+    def certificate_download_path
+      download_path_by_platfrom || download_path_by_order_specified_platfrom
+    end
+
+    def download_path_by_platfrom
+      if platform
+        [resource_path, "platform", platform].join("/")
+      end
+    end
+
+    def download_path_by_order_specified_platfrom
+      [resource_path, "platform"].join("/")
     end
   end
 end

--- a/spec/acceptance/certificate_download_spec.rb
+++ b/spec/acceptance/certificate_download_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "Download a certificate" do
     # all requiremetns are meet and let's fetch the certificate
     #
     certificate_id = certificate_order.certificate.id
-    stub_digicert_certificate_content_fetch_api(certificate_id)
+    stub_digicert_certificate_download_by_platform(certificate_id)
     certificate = Digicert::CertificateDownloader.fetch(certificate_id)
 
     # Normally zip archieves content starts with `PK` and then

--- a/spec/digicert/certificate_downloader_spec.rb
+++ b/spec/digicert/certificate_downloader_spec.rb
@@ -5,19 +5,38 @@ RSpec.describe Digicert::CertificateDownloader do
     it "retrives the certificate contents" do
       certificate_id = 123_456_789
 
-      stub_digicert_certificate_content_fetch_api(certificate_id)
+      stub_digicert_certificate_download_by_platform(certificate_id)
       certificate = Digicert::CertificateDownloader.fetch(certificate_id)
 
-      # The response we get from the certificate downloader is
-      # a file, and it's a `.zip` to be more specific. The easiest
-      # way to verify if it's a .zip file or not is not check the
-      # file content, and if it starts with `PK` then it is more
-      # likely a zip archieve
-      #
-      # Source: http://filext.com/faq/look_into_files.php
-      #
       expect(certificate.code.to_i).to eq(200)
-      expect(certificate.body.start_with?("PK")).to eq(true)
+      expect_certficate_to_be_a_zip_archieve(certificate)
     end
+  end
+
+  describe ".fetch_by_platform" do
+    it "retrieves a certificate by specified platform" do
+      platform = "apache"
+      certificate_id = 123_456_789
+
+      stub_digicert_certificate_download_by_platform(certificate_id, platform)
+      certificate = Digicert::CertificateDownloader.fetch_by_platform(
+        certificate_id, platform: platform,
+      )
+
+      expect(certificate.code.to_i).to eq(200)
+      expect_certficate_to_be_a_zip_archieve(certificate)
+    end
+  end
+
+  def expect_certficate_to_be_a_zip_archieve(certificate)
+    # The response we get from the certificate downloader is
+    # a file, and it's a `.zip` to be more specific. The easiest
+    # way to verify if it's a .zip file or not is not check the
+    # file content, and if it starts with `PK` then it is more
+    # likely a zip archieve
+    #
+    # Source: http://filext.com/faq/look_into_files.php
+    #
+    expect(certificate.body.start_with?("PK")).to eq(true)
   end
 end

--- a/spec/support/fake_digicert_api.rb
+++ b/spec/support/fake_digicert_api.rb
@@ -164,23 +164,25 @@ module Digicert
       )
     end
 
-    def stub_digicert_certificate_content_fetch_api(id)
-      end_point = ["certificate", id, "download", "platform"].join("/")
-
-      stub_request(:get, digicert_api_end_point(end_point)).
-        with(digicert_api_request_headers(data: nil)).
-        to_return(
-          body: File.new(
-            File.expand_path("../../fixtures/certificate.zip", __FILE__)
-          ),
-          status: 200,
-        )
+    def stub_digicert_certificate_download_by_platform(id, platform = nil)
+      stub_api_response_with_io(
+        :get,
+        ["certificate", id, "download", "platform", platform].compact.join("/"),
+        filename: "certificate.zip",
+        status: 200,
+      )
     end
 
     def stub_api_response(method, end_point, filename:, status: 200, data: nil)
       stub_request(method, digicert_api_end_point(end_point)).
         with(digicert_api_request_headers(data: data)).
         to_return(response_with(filename: filename, status: status))
+    end
+
+    def stub_api_response_with_io(method, end_point, filename:, status: 200)
+      stub_request(method, digicert_api_end_point(end_point)).
+        with(digicert_api_request_headers(data: nil)).
+        to_return(response_with_file(file: filename, status: status))
     end
 
     private
@@ -205,6 +207,13 @@ module Digicert
 
     def response_with(filename:, status:)
       { body: digicert_fixture(filename), status: status }
+    end
+
+    def response_with_file(file:, status:)
+      {
+        status: status,
+        body: File.new(File.expand_path("../../fixtures/#{file}", __FILE__)),
+      }
     end
 
     def api_key_header


### PR DESCRIPTION
This commit adds an interface to retrieve an SSL Certificate file from an order using the platform specified with it. To download a certificate by platform use.

```ruby
Digicert::CertificateDownloader.fetch_by_platform(
  certificate_id, platform: platform_name_id,
)
```