### PR TITLE
Download a certificate by a format

### DIFF
--- a/README.md
+++ b/README.md
@@ -498,6 +498,19 @@ certificate = Digicert::CertificateDownloader.fetch(certificate_id)
 File.write("path_to_file_system/certificate.zip", certificate.body)
 ```
 
+#### Download a Certificate By Format
+
+This interface will return an SSL Certificate file from an order. The certificate
+will be return in the format you specify, but one thing to remember the
+certificate will be archived as `zip` along with the instructions, so you need
+to write that as zip archive.
+
+```ruby
+Digicert::CertificateDownloader.fetch_by_format(
+  certificate_id, format: format,
+)
+```
+
 #### Download a Certificate By Platform
 
 This interface will return an SSL Certificate file from an order using the

--- a/lib/digicert/certificate_downloader.rb
+++ b/lib/digicert/certificate_downloader.rb
@@ -3,6 +3,7 @@ require "digicert/base"
 module Digicert
   class CertificateDownloader < Digicert::Base
     def initialize(attributes = {})
+      @format = attributes.delete(:format)
       @platform = attributes.delete(:platform)
       super
     end
@@ -11,20 +12,32 @@ module Digicert
       Digicert::Request.new(:get, certificate_download_path).run
     end
 
+    def self.fetch_by_format(certificate_id, format:)
+      new(resource_id: certificate_id, format: format).fetch
+    end
+
     def self.fetch_by_platform(certificate_id, platform:)
       new(resource_id: certificate_id, platform: platform).fetch
     end
 
     private
 
-    attr_reader :platform
+    attr_reader :format, :platform
 
     def resource_path
       ["certificate", resource_id, "download"].join("/")
     end
 
     def certificate_download_path
-      download_path_by_platfrom || download_path_by_order_specified_platfrom
+      download_path_by_format ||
+        download_path_by_platfrom ||
+        download_path_by_order_specified_platfrom
+    end
+
+    def download_path_by_format
+      if format
+        [resource_path, "format", format].join("/")
+      end
     end
 
     def download_path_by_platfrom

--- a/spec/digicert/certificate_downloader_spec.rb
+++ b/spec/digicert/certificate_downloader_spec.rb
@@ -28,6 +28,21 @@ RSpec.describe Digicert::CertificateDownloader do
     end
   end
 
+  describe ".fetch_by_format" do
+    it "retrives a certificate by specified format" do
+      format = "pem"
+      certificate_id = 123_456_789
+
+      stub_digicert_certificate_download_by_format(certificate_id, format)
+      certificate = Digicert::CertificateDownloader.fetch_by_format(
+        certificate_id, format: format,
+      )
+
+      expect(certificate.code.to_i).to eq(200)
+      expect_certficate_to_be_a_zip_archieve(certificate)
+    end
+  end
+
   def expect_certficate_to_be_a_zip_archieve(certificate)
     # The response we get from the certificate downloader is
     # a file, and it's a `.zip` to be more specific. The easiest

--- a/spec/support/fake_digicert_api.rb
+++ b/spec/support/fake_digicert_api.rb
@@ -164,6 +164,15 @@ module Digicert
       )
     end
 
+    def stub_digicert_certificate_download_by_format(id, format)
+      stub_api_response_with_io(
+        :get,
+        ["certificate", id, "download", "format", format].join("/"),
+        filename: "certificate.zip",
+        status: 200,
+      )
+    end
+
     def stub_digicert_certificate_download_by_platform(id, platform = nil)
       stub_api_response_with_io(
         :get,


### PR DESCRIPTION
This commit adds an interface to retrieve a certificate content in a format you specify, but one thing to remember, the certificate will be archived as `zip`, so we need to write it as zip but if if extract it then it will be in the format we specified.

```ruby
Digicert::CertificateDownloader.fetch_by_format(
  certificate_id, format: your_desire_format,
)
```