### PR TITLE
Add interface to list email validations

### DIFF
--- a/README.md
+++ b/README.md
@@ -522,6 +522,24 @@ certificate = Digicert::CertificateDownloader.fetch_by_platform(
 )
 ```
 
+### Email Validations
+
+#### List of Email Validations
+
+Use this interface to view the status of all emails that require validation on a
+client certificate order.
+
+```ruby
+Digicert::EmailValidation.all(order_id: order_id)
+
+# If you prefer then there is an alternative alias method
+# on the order class, you can invoke that on any of its
+# instances. Usages
+#
+order = Digicert::Order.find(order_id)
+order.email_validations
+```
+
 ## Play Box
 
 The API Play Box provides an interactive console so we can easily test out the

--- a/lib/digicert.rb
+++ b/lib/digicert.rb
@@ -17,6 +17,7 @@ require "digicert/container_template"
 require "digicert/container"
 require "digicert/domain"
 require "digicert/certificate_downloader"
+require "digicert/email_validation"
 
 module Digicert
 

--- a/lib/digicert/base.rb
+++ b/lib/digicert/base.rb
@@ -13,6 +13,25 @@ module Digicert
       @resource_id = @attributes.delete(:resource_id)
     end
 
+    # The `.find` interface is just an alternvatie to instantiate
+    # a new object, and please remeber this does not perform any
+    # actual API Request. Use this interface whenever you need to
+    # instantite an object from an existing id and then perform
+    # some operation throught the objec's instnace methods, like
+    # `#active`, `#reissue` and etc
+    #
+    # If you need an actual API response then use the `.fetch`
+    # API, that will perform an actual API Reqeust and will return
+    # the response from the Digicer API.
+    #
+    # We are not going to implement this right away, but in long
+    # run may be we cna add some sort to lazy evaluation on this
+    # interface, but that's not for sure.
+    #
+    def self.find(resource_id)
+      new(resource_id: resource_id)
+    end
+
     private
 
     attr_reader :attributes, :resource_id, :query_params

--- a/lib/digicert/domain.rb
+++ b/lib/digicert/domain.rb
@@ -17,25 +17,6 @@ module Digicert
       ).parse
     end
 
-    # The `.find` interface is just an alternvatie to instantiate
-    # a new object, and please remeber this does not perform any
-    # actual API Request. Use this interface whenever you need to
-    # instantite an object from an existing id and then perform
-    # some operation throught the objec's instnace methods, like
-    # `#active` and `#deactivate`.
-    #
-    # If you need an actual API response then use the `.fetch`
-    # API, that will perform an actual API Reqeust and will return
-    # the response from the Digicer API.
-    #
-    # We are not going to implement this right away, but in long
-    # run may be we cna add some sort to lazy evaluation on this
-    # interface, but that's not for sure.
-    #
-    def self.find(domain_id)
-      new(resource_id: domain_id)
-    end
-
     private
 
     def resource_path

--- a/lib/digicert/email_validation.rb
+++ b/lib/digicert/email_validation.rb
@@ -1,0 +1,25 @@
+require "digicert/base"
+
+module Digicert
+  class EmailValidation < Digicert::Base
+    def initialize(attributes = {})
+      @order_id = attributes.delete(:order_id)
+    end
+
+    def self.all(order_id:, **filter_params)
+      new(order_id: order_id, params: filter_params).all
+    end
+
+    private
+
+    attr_reader :order_id
+
+    def resources_key
+      "emails"
+    end
+
+    def resource_path
+      ["order", "certificate", order_id, "email-validation"].join("/")
+    end
+  end
+end

--- a/lib/digicert/order.rb
+++ b/lib/digicert/order.rb
@@ -23,6 +23,10 @@ module Digicert
       certificate_klass.create(attributes)
     end
 
+    def email_validations
+      Digicert::EmailValidation.all(order_id: resource_id)
+    end
+
     def self.create(name_id, attributes)
       new(name_id: name_id, **attributes).create
     end

--- a/spec/digicert/email_validation_spec.rb
+++ b/spec/digicert/email_validation_spec.rb
@@ -1,0 +1,15 @@
+require "spec_helper"
+
+RSpec.describe Digicert::EmailValidation do
+  describe ".all" do
+    it "retrieves the list of email with validation status" do
+      order_id = 123_456_789
+
+      stub_digicert_email_validations_api(order_id)
+      email_validations = Digicert::EmailValidation.all(order_id: order_id)
+
+      expect(email_validations.first.status).to eq("validated")
+      expect(email_validations.first.email).to eq("email@example.com")
+    end
+  end
+end

--- a/spec/digicert/order_spec.rb
+++ b/spec/digicert/order_spec.rb
@@ -38,6 +38,19 @@ RSpec.describe Digicert::Order do
     end
   end
 
+  describe "#email_validations" do
+    it "retrieves list of emails with validation status" do
+      order_id = 123_456_789
+      order = Digicert::Order.find(order_id)
+
+      stub_digicert_email_validations_api(order_id)
+      email_validations = order.email_validations
+
+      expect(email_validations.first.status).to eq("validated")
+      expect(email_validations.first.email).to eq("email@example.com")
+    end
+  end
+
   def order_attributes
     {
       certificate: {

--- a/spec/fixtures/email_validations.json
+++ b/spec/fixtures/email_validations.json
@@ -1,0 +1,17 @@
+{
+  "delivery_options": [
+    "browser"
+  ],
+  "emails": [
+    {
+      "email": "email@example.com",
+      "status": "validated",
+      "date_emailed": "2013-05-02"
+    },
+    {
+      "email": "email2@example2.com",
+      "status": "unvalidated",
+      "date_emailed": "2013-05-02"
+    }
+  ]
+}

--- a/spec/support/fake_digicert_api.rb
+++ b/spec/support/fake_digicert_api.rb
@@ -164,6 +164,15 @@ module Digicert
       )
     end
 
+    def stub_digicert_email_validations_api(order_id)
+      stub_api_response(
+        :get,
+        ["order", "certificate", order_id, "email-validation"].join("/"),
+        filename: "email_validations",
+        status: 200,
+      )
+    end
+
     def stub_digicert_certificate_download_by_format(id, format)
       stub_api_response_with_io(
         :get,


### PR DESCRIPTION
This commit adds the interface to retrieve the list of all email validations for a specific `order_id`, this also move the `find` to base class so all of it's subclass can use this to instantiate a new object using an existing `resource_id`.

```ruby
Digicert::EmailValidation.all(order_id: order_id)

# The alternative interface to order instance
order = Digicert::Order.find(order_id)
order.email_validations
```