### PR TITLE
Add interface to validate an email

### DIFF
--- a/README.md
+++ b/README.md
@@ -540,6 +540,16 @@ order = Digicert::Order.find(order_id)
 order.email_validations
 ```
 
+#### Validate an Email Address
+
+Use this interface to verify control of an email address, using an email
+address/token pair.
+
+```ruby
+Digicert::EmailValidation.valid?(token: token, email: email)
+# => true or false
+```
+
 ## Play Box
 
 The API Play Box provides an interactive console so we can easily test out the

--- a/lib/digicert/email_validation.rb
+++ b/lib/digicert/email_validation.rb
@@ -10,6 +10,14 @@ module Digicert
       new(order_id: order_id, params: filter_params).all
     end
 
+    def self.valid?(token:, email:)
+      response = Digicert::Request.new(
+        :put, ["email-validation", token].join("/"), params: {email: email }
+      ).run
+
+      response.code.to_i == 204
+    end
+
     private
 
     attr_reader :order_id

--- a/spec/digicert/email_validation_spec.rb
+++ b/spec/digicert/email_validation_spec.rb
@@ -12,4 +12,15 @@ RSpec.describe Digicert::EmailValidation do
       expect(email_validations.first.email).to eq("email@example.com")
     end
   end
+
+  describe ".valid?" do
+    it "validates the email through digicert" do
+      validation_attributes = { token: "token", email: "email@example.com" }
+      stub_digicert_email_validations_validate_api(validation_attributes)
+
+      expect(
+        Digicert::EmailValidation.valid?(validation_attributes),
+      ).to eq(true)
+    end
+  end
 end

--- a/spec/support/fake_digicert_api.rb
+++ b/spec/support/fake_digicert_api.rb
@@ -173,6 +173,15 @@ module Digicert
       )
     end
 
+    def stub_digicert_email_validations_validate_api(token:, email:)
+      stub_api_response(
+        :put,
+        path_with_query("email-validation/#{token}", email: email),
+        filename: "empty",
+        status: 204,
+      )
+    end
+
     def stub_digicert_certificate_download_by_format(id, format)
       stub_api_response_with_io(
         :get,


### PR DESCRIPTION
This commit adds an interface verify control of an email address, using an email address/token pair. All you need to do is pass the `token` and `email` and it will return a boolean based on the API response from Digicert. Usage

```ruby
Digicert::EmailValidation.valid?(token: token, email: email)
```