### PR TITLE
Interface to list duplicate certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,18 @@ Digicert::OrderDuplicator.create(
 )
 ```
 
+#### List Duplicate Certificates
+
+Use this interface to view all duplicate certificates for an order.
+
+```ruby
+Digicert::DuplicateCertificate.all(order_id: order_id)
+
+# Alternative interface for duplicate certificates
+order = Digicert::Order.find(order_id)
+order.duplicate_certificates
+```
+
 #### View a Certificate Order
 
 Use this interface to retrieve a certificate order and the response includes all

--- a/lib/digicert.rb
+++ b/lib/digicert.rb
@@ -20,6 +20,7 @@ require "digicert/certificate_downloader"
 require "digicert/email_validation"
 require "digicert/order_reissuer"
 require "digicert/order_duplicator"
+require "digicert/duplicate_certificate"
 
 module Digicert
 

--- a/lib/digicert/duplicate_certificate.rb
+++ b/lib/digicert/duplicate_certificate.rb
@@ -1,0 +1,28 @@
+require "digicert/actions/all"
+
+module Digicert
+  class DuplicateCertificate
+    include Digicert::Actions::All
+
+    def initialize(order_id:, params: {})
+      @order_id = order_id
+      @query_params = params
+    end
+
+    def self.all(order_id:, **attributes)
+      new(order_id: order_id, **attributes).all
+    end
+
+    private
+
+    attr_reader :order_id, :query_params
+
+    def resources_key
+      "certificates"
+    end
+
+    def resource_path
+      ["order", "certificate", order_id, "duplicate"].join("/")
+    end
+  end
+end

--- a/lib/digicert/order.rb
+++ b/lib/digicert/order.rb
@@ -35,6 +35,10 @@ module Digicert
       Digicert::OrderDuplicator.create(order_id: resource_id)
     end
 
+    def duplicate_certificates
+      Digicert::DuplicateCertificate.all(order_id: resource_id)
+    end
+
     def email_validations
       Digicert::EmailValidation.all(order_id: resource_id)
     end

--- a/spec/digicert/duplicate_certificate_spec.rb
+++ b/spec/digicert/duplicate_certificate_spec.rb
@@ -1,0 +1,15 @@
+require "spec_helper"
+
+RSpec.describe Digicert::DuplicateCertificate do
+  describe ".all" do
+    it "list all duplicate certificates" do
+      order_id = 123_456_789
+
+      stub_digicert_order_duplications_api(order_id)
+      certificates = Digicert::DuplicateCertificate.all(order_id: order_id)
+
+      expect(certificates.first.id).not_to be_nil
+      expect(certificates.first.status).to eq("approved")
+    end
+  end
+end

--- a/spec/digicert/order_spec.rb
+++ b/spec/digicert/order_spec.rb
@@ -79,6 +79,20 @@ RSpec.describe Digicert::Order do
     end
   end
 
+  describe "#duplicate_certificates" do
+    it "sends all message to order duplication" do
+      order_id = 123_456_789
+      order = Digicert::Order.find(order_id)
+      allow(Digicert::DuplicateCertificate).to receive(:all)
+
+      order.duplicate_certificates
+
+      expect(
+        Digicert::DuplicateCertificate
+      ).to have_received(:all).with(order_id: order_id)
+    end
+  end
+
   def order_attributes
     {
       certificate: {

--- a/spec/fixtures/order_duplications.json
+++ b/spec/fixtures/order_duplications.json
@@ -1,0 +1,57 @@
+{
+  "certificates": [
+    {
+      "id": 1,
+      "thumbprint": "B71DCBAF5586D6D95FC0B7EA1C74ADEF4A99F960",
+      "serial_number": "0AE71279E5213729026AFE4BB58DE1AB",
+      "common_name": "*.digicert.com",
+      "dns_names": [
+        "*.digicert.com",
+        "digicert.com"
+      ],
+      "status": "approved",
+      "date_created": "2014-08-19T18:16:07+00:00",
+      "valid_from": "2014-08-19",
+      "valid_till": "2015-08-24",
+      "csr": "------ [CSR HERE] ------",
+      "server_platform": {
+        "id": 45,
+        "name": "Barracuda",
+        "install_url": "www.install.com",
+        "csr_url": "www.csr.com"
+      },
+      "signature_hash": "sha256",
+      "key_size": 2048,
+      "ca_cert_id": "B71DCBAF5586D6D95FC0B7EA1C74ADEF4A99F960",
+      "sub_id": "001",
+      "public_id": "F7QIRX5P462QUYGQGRF26RSTL"
+    },
+    {
+      "id": 2,
+      "thumbprint": "B71DCBAF5586D6D95FC0B7EA1C74ADEF4A99F960",
+      "serial_number": "0AE71279E5213729026AFE4BB58DE1AB",
+      "common_name": "*.digicert.com",
+      "dns_names": [
+        "*.digicert.com",
+        "digicert.com",
+        "subdomain.digicert.com"
+      ],
+      "status": "approved",
+      "date_created": "2014-08-19T18:16:07+00:00",
+      "valid_from": "2014-08-19",
+      "valid_till": "2015-08-24",
+      "csr": "------ [CSR HERE] ------",
+      "server_platform": {
+        "id": 45,
+        "name": "Barracuda",
+        "install_url": "www.install.com",
+        "csr_url": "www.csr.com"
+      },
+      "signature_hash": "sha256",
+      "key_size": 2048,
+      "ca_cert_id": "B71DCBAF5586D6D95FC0B7EA1C74ADEF4A99F960",
+      "sub_id": "002",
+      "public_id": "F7QIRX5P462QUYGQGRF26VLK"
+    }
+  ]
+}

--- a/spec/support/fake_digicert_api.rb
+++ b/spec/support/fake_digicert_api.rb
@@ -202,6 +202,15 @@ module Digicert
       )
     end
 
+    def stub_digicert_order_duplications_api(order_id)
+      stub_api_response(
+        :get,
+        ["order", "certificate", order_id, "duplicate"].join("/"),
+        filename: "order_duplications",
+        status: 200,
+      )
+    end
+
     def stub_digicert_certificate_download_by_format(id, format)
       stub_api_response_with_io(
         :get,


### PR DESCRIPTION
This commit adds the interface to list duplicate certificates using the Digicert Order Management API. Usage

```ruby
Digicert::DuplicateCertificate.all(order_id: order_id)
```