### PR TITLE
Add interface to cancel a certificate order

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,21 @@ order = Digicert::Order.find(order_id)
 order.duplicate_certificates
 ```
 
+#### Cancel a Certificate Order
+
+Use this interface to update the status of an order. Currently this endpoint only
+allows updating the status to 'CANCELED'
+
+```ruby
+order = Digicert::Order.find(order_id)
+order.cancel(note: "Cancellation note")
+
+# Or use the actual interface for more control
+Digicert::OrderCancellation.create(
+  order_id: order_id, status: "CANCELED", note: "your_note", send_emails: true,
+)
+```
+
 #### View a Certificate Order
 
 Use this interface to retrieve a certificate order and the response includes all

--- a/lib/digicert.rb
+++ b/lib/digicert.rb
@@ -21,6 +21,7 @@ require "digicert/email_validation"
 require "digicert/order_reissuer"
 require "digicert/order_duplicator"
 require "digicert/duplicate_certificate"
+require "digicert/order_cancellation"
 
 module Digicert
 

--- a/lib/digicert/order.rb
+++ b/lib/digicert/order.rb
@@ -43,6 +43,12 @@ module Digicert
       Digicert::EmailValidation.all(order_id: resource_id)
     end
 
+    def cancel(note:, **attrs)
+      Digicert::OrderCancellation.create(
+        order_id: resource_id, note: note, **attrs,
+      )
+    end
+
     private
 
     def resource_path

--- a/lib/digicert/order_cancellation.rb
+++ b/lib/digicert/order_cancellation.rb
@@ -1,0 +1,30 @@
+module Digicert
+  class OrderCancellation
+    def initialize(order_id:, **attributes)
+      @order_id = order_id
+      @attributes = attributes
+    end
+
+    def create
+      Digicert::Request.new(
+        :put, resource_path, default_attributes.merge(attributes),
+      ).run
+    end
+
+    def self.create(order_id:, note:, **attributes)
+      new(attributes.merge(order_id: order_id, note: note)).create
+    end
+
+    private
+
+    attr_reader :order_id, :attributes
+
+    def resource_path
+      ["order", "certificate", order_id, "status"].join("/")
+    end
+
+    def default_attributes
+      { status: "CANCELED", send_emails: false }
+    end
+  end
+end

--- a/spec/digicert/order_cancellation_spec.rb
+++ b/spec/digicert/order_cancellation_spec.rb
@@ -1,0 +1,24 @@
+require "spec_helper"
+
+RSpec.describe Digicert::OrderCancellation do
+  describe ".create" do
+    it "cancels an existing order" do
+      order_id = 123_456_789
+
+      stub_digicert_order_cancellation_api(order_id, cancellation_attributes)
+      order_cancellation = Digicert::OrderCancellation.create(
+        order_id: order_id, **cancellation_attributes,
+      )
+
+      expect(order_cancellation.code.to_i).to eq(204)
+    end
+  end
+
+  def cancellation_attributes
+    {
+      status: "CANCELED",
+      send_emails: true,
+      note: "This is a cancellation note",
+    }
+  end
+end

--- a/spec/digicert/order_spec.rb
+++ b/spec/digicert/order_spec.rb
@@ -93,6 +93,22 @@ RSpec.describe Digicert::Order do
     end
   end
 
+  describe "#cancel" do
+    it "sends the create methods to order cancellation" do
+      order_id = 123_456_789
+      note = "This is the cancellation note"
+
+      order = Digicert::Order.find(order_id)
+      allow(Digicert::OrderCancellation).to receive(:create)
+
+      order.cancel(note: note)
+
+      expect(
+        Digicert::OrderCancellation
+      ).to have_received(:create).with(order_id: order_id, note: note)
+    end
+  end
+
   def order_attributes
     {
       certificate: {

--- a/spec/support/fake_digicert_api.rb
+++ b/spec/support/fake_digicert_api.rb
@@ -211,6 +211,16 @@ module Digicert
       )
     end
 
+    def stub_digicert_order_cancellation_api(order_id, attributes)
+      stub_api_response(
+        :put,
+        ["order", "certificate", order_id, "status"].join("/"),
+        data: attributes,
+        filename: "empty",
+        status: 204,
+      )
+    end
+
     def stub_digicert_certificate_download_by_format(id, format)
       stub_api_response_with_io(
         :get,


### PR DESCRIPTION
This commit adds the interface to cancel an existing certificate order, by default it sets the `status` to `CANCELLED` and the `send_emails` to `true`, but that can be overridden passing the additional options hash.

```ruby
Digicert::OrderCancellation.create(
  order_id: order_id, note: "cancellation note",
)

# alternative through the order instance

order = Digicert::Order.find(order_id)
order.cancel(note: "Cancellation note", **attributes)
```