### PR TITLE
Add interface to retrieve expiring orders

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,16 @@ Digicert::OrderCancellation.create(
 )
 ```
 
+#### Expiring Orders
+
+Use this interface to retrieve the number of orders that have certificates
+expiring within 90, 60, and 30 days. The number of orders that have already
+expired certificates within the last 7 days is also returned.
+
+```ruby
+Digicert::ExpiringOrder.all(container_id: container_id)
+```
+
 #### View a Certificate Order
 
 Use this interface to retrieve a certificate order and the response includes all

--- a/lib/digicert.rb
+++ b/lib/digicert.rb
@@ -22,6 +22,7 @@ require "digicert/order_reissuer"
 require "digicert/order_duplicator"
 require "digicert/duplicate_certificate"
 require "digicert/order_cancellation"
+require "digicert/expiring_order"
 
 module Digicert
 

--- a/lib/digicert/expiring_order.rb
+++ b/lib/digicert/expiring_order.rb
@@ -1,0 +1,28 @@
+require "digicert/actions/base"
+
+module Digicert
+  class ExpiringOrder
+    include Digicert::Actions::All
+
+    def initialize(container_id:, params: {})
+      @query_params = params
+      @container_id = container_id
+    end
+
+    def self.all(container_id:, **filter_params)
+      new(container_id: container_id, params: filter_params).all
+    end
+
+    private
+
+    attr_reader :container_id, :query_params
+
+    def resources_key
+      "expiring_orders"
+    end
+
+    def resource_path
+      ["report", "order", container_id, "expiring"].join("/")
+    end
+  end
+end

--- a/spec/digicert/expiring_order_spec.rb
+++ b/spec/digicert/expiring_order_spec.rb
@@ -1,0 +1,16 @@
+require "spec_helper"
+
+RSpec.describe Digicert::ExpiringOrder do
+  describe ".all" do
+    it "retrieves all the expiring orders" do
+      container_id = 123_456_789
+
+      stub_digicert_order_expiring_api(container_id)
+      expiring_orders = Digicert::ExpiringOrder.all(container_id: container_id)
+
+      expect(expiring_orders.count).to eq(4)
+      expect(expiring_orders.first.order_count).to eq(10)
+      expect(expiring_orders.first.days_expiring).to eq(90)
+    end
+  end
+end

--- a/spec/fixtures/expiring_orders.json
+++ b/spec/fixtures/expiring_orders.json
@@ -1,0 +1,20 @@
+{
+  "expiring_orders": [
+    {
+      "days_expiring": 90,
+      "order_count": 10
+    },
+    {
+      "days_expiring": 60,
+      "order_count": 13
+    },
+    {
+      "days_expiring": 30,
+      "order_count": 3
+    },
+    {
+      "days_expiring": -7,
+      "order_count": 1
+    }
+  ]
+}

--- a/spec/support/fake_digicert_api.rb
+++ b/spec/support/fake_digicert_api.rb
@@ -221,6 +221,15 @@ module Digicert
       )
     end
 
+    def stub_digicert_order_expiring_api(container_id)
+      stub_api_response(
+        :get,
+        ["report", "order", container_id, "expiring"].join("/"),
+        filename: "expiring_orders",
+        status: 200,
+      )
+    end
+
     def stub_digicert_certificate_download_by_format(id, format)
       stub_api_response_with_io(
         :get,


### PR DESCRIPTION
This commit adds the interface to retrieve the number of orders that have certificates expiring within 90, 60, and 30 days. The number of orders that have already expired certificates within the last 7 days is also returned. Usages

```ruby
Digicert::ExpiringOrder.all(container_id: container_id)
```