### PR TITLE
Remove custom object initialization

### DIFF
--- a/lib/digicert/base.rb
+++ b/lib/digicert/base.rb
@@ -9,8 +9,9 @@ module Digicert
 
     def initialize(attributes = {})
       @attributes = attributes
-      @query_params = @attributes.delete(:params)
-      @resource_id = @attributes.delete(:resource_id)
+
+      extract_base_attribute_ids
+      extract_local_attribute_ids
     end
 
     # The `.find` interface is just an alternvatie to instantiate
@@ -35,6 +36,18 @@ module Digicert
     private
 
     attr_reader :attributes, :resource_id, :query_params
+
+    def extract_base_attribute_ids
+      @query_params = attributes.delete(:params)
+      @resource_id = attributes.delete(:resource_id)
+    end
+
+    def extract_local_attribute_ids
+      # Implement this to extract ids that are specific
+      # to each of the specific classes, for example
+      #
+      # @order_id = attributes.delete(:order_id)
+    end
 
     def resources_key
       [resource_path, "s"].join

--- a/lib/digicert/certificate_downloader.rb
+++ b/lib/digicert/certificate_downloader.rb
@@ -2,12 +2,6 @@ require "digicert/base"
 
 module Digicert
   class CertificateDownloader < Digicert::Base
-    def initialize(attributes = {})
-      @format = attributes.delete(:format)
-      @platform = attributes.delete(:platform)
-      super
-    end
-
     def fetch
       Digicert::Request.new(:get, certificate_download_path).run
     end
@@ -23,6 +17,11 @@ module Digicert
     private
 
     attr_reader :format, :platform
+
+    def extract_local_attribute_ids
+      @format = attributes.delete(:format)
+      @platform = attributes.delete(:platform)
+    end
 
     def resource_path
       ["certificate", resource_id, "download"].join("/")

--- a/lib/digicert/container.rb
+++ b/lib/digicert/container.rb
@@ -5,16 +5,15 @@ module Digicert
   class Container < Digicert::Base
     include Digicert::Actions::Create
 
-    def initialize(attributes = {})
-      @container_id = attributes.delete(:container_id)
-      super
-    end
-
     def self.create(container_id:, **attributes)
       new(attributes.merge(container_id: container_id)).create
     end
 
     private
+
+    def extract_local_attribute_ids
+      @container_id = attributes.delete(:container_id)
+    end
 
     def validate(name:, template_id:, **attributes)
       required_attributes = {

--- a/lib/digicert/container_template.rb
+++ b/lib/digicert/container_template.rb
@@ -2,11 +2,6 @@ require "digicert/base"
 
 module Digicert
   class ContainerTemplate < Base
-    def initialize(attributes = {})
-      @container_id = attributes.delete(:container_id)
-      super
-    end
-
     def self.all(container_id)
       new(container_id: container_id).all
     end
@@ -16,6 +11,10 @@ module Digicert
     end
 
     private
+
+    def extract_local_attribute_ids
+      @container_id = attributes.delete(:container_id)
+    end
 
     def resources_key
       "container_templates"

--- a/lib/digicert/email_validation.rb
+++ b/lib/digicert/email_validation.rb
@@ -2,10 +2,6 @@ require "digicert/base"
 
 module Digicert
   class EmailValidation < Digicert::Base
-    def initialize(attributes = {})
-      @order_id = attributes.delete(:order_id)
-    end
-
     def self.all(order_id:, **filter_params)
       new(order_id: order_id, params: filter_params).all
     end
@@ -21,6 +17,10 @@ module Digicert
     private
 
     attr_reader :order_id
+
+    def extract_local_attribute_ids
+      @order_id = attributes.delete(:order_id)
+    end
 
     def resources_key
       "emails"

--- a/lib/digicert/order.rb
+++ b/lib/digicert/order.rb
@@ -14,11 +14,6 @@ require "digicert/client_certificate/digital_signature_plus"
 
 module Digicert
   class Order < Digicert::Base
-    def initialize(attributes = {})
-      @name_id = attributes.delete(:name_id)
-      super
-    end
-
     def create
       certificate_klass.create(attributes)
     end
@@ -50,6 +45,10 @@ module Digicert
     end
 
     private
+
+    def extract_local_attribute_ids
+      @name_id = attributes.delete(:name_id)
+    end
 
     def resource_path
       "order/certificate"


### PR DESCRIPTION
Currently, each of the `Digicert::Base` subclass was rewriting the `initialize` method to extract some of the attributes that is local to that class. This way every class know too much than they actually need to and if they forget to call the `super` than those won't work properly. Which is kind of against the single responsibility principle and might be hard to maintain in the long run.

This commit removes this by implementing hook kind of method, so if we needs to extract some ids than we do not need to rewrite the whole initialization method but all we need to do is define `extract_local_attribute_ids` and extract the attrs. This was every class does not need to know how to implement the `initialize` that does not break anything it was not supposed to do.