### PR TITLE
Extract `update` action to a module

### DIFF
--- a/lib/digicert/actions/update.rb
+++ b/lib/digicert/actions/update.rb
@@ -1,0 +1,25 @@
+require "digicert/actions/base"
+
+module Digicert
+  module Actions
+    module Update
+      extend Digicert::Actions::Base
+
+      def update
+        Digicert::Request.new(
+          :put, resource_update_path, attributes,
+        ).run
+      end
+
+      def resource_update_path
+        [resource_path, resource_id].join("/")
+      end
+
+      module ClassMethods
+        def update(resource_id, attributes)
+          new(resource_id: resource_id, **attributes).update
+        end
+      end
+    end
+  end
+end

--- a/lib/digicert/certificate_request.rb
+++ b/lib/digicert/certificate_request.rb
@@ -1,17 +1,9 @@
 require "digicert/base"
+require "digicert/actions/update"
 
 module Digicert
   class CertificateRequest < Digicert::Base
-
-    def update
-      Digicert::Request.new(
-        :put, update_status_path, attributes,
-      ).parse
-    end
-
-    def self.update(resource_id, attributes)
-      new(resource_id: resource_id, **attributes).update
-    end
+    include Digicert::Actions::Update
 
     private
 
@@ -19,7 +11,7 @@ module Digicert
       "request"
     end
 
-    def update_status_path
+    def resource_update_path
       [resource_path, resource_id, "status"].join("/")
     end
   end

--- a/spec/digicert/actions/update_spec.rb
+++ b/spec/digicert/actions/update_spec.rb
@@ -1,0 +1,39 @@
+require "spec_helper"
+require "digicert/base"
+require "digicert/actions/update"
+
+RSpec.describe "Digicert::Actions::Update" do
+  describe ".update" do
+    it "updates the resource attributes" do
+      resource_id = 123_456_789
+      stub_digicert_certificate_request_update_api(
+        resource_id, certificate_status_attributes,
+      )
+
+      resource = Digicert::TestUpdateAction.update(
+        resource_id, certificate_status_attributes,
+      )
+
+      expect(resource.code.to_i).to eq(204)
+    end
+  end
+
+  module Digicert
+    class TestUpdateAction < Digicert::Base
+      include Digicert::Actions::Update
+
+      private
+
+      def resource_update_path
+        ["request", resource_id, "status"].join("/")
+      end
+    end
+  end
+
+  def certificate_status_attributes
+    {
+      status: "approved",
+      processor_comment: "Your domain is approved",
+    }
+  end
+end


### PR DESCRIPTION
This commit extract the `update` action to a separate module, so we can use this one whenever we will need the update functionality on any of of the resources.