### PR TITLE
Support `attributes` for order instance

### DIFF
--- a/lib/digicert/container_template.rb
+++ b/lib/digicert/container_template.rb
@@ -1,7 +1,7 @@
 require "digicert/base"
 
 module Digicert
-  class ContainerTemplate < Base
+  class ContainerTemplate < Digicert::Base
     include Digicert::Actions::All
     include Digicert::Actions::Fetch
 
@@ -15,6 +15,8 @@ module Digicert
 
     private
 
+    attr_reader :container_id
+
     def extract_local_attribute_ids
       @container_id = attributes.delete(:container_id)
     end
@@ -24,7 +26,7 @@ module Digicert
     end
 
     def resource_path
-      ["container", @container_id, "template"].join("/")
+      ["container", container_id, "template"].join("/")
     end
   end
 end

--- a/lib/digicert/order.rb
+++ b/lib/digicert/order.rb
@@ -2,7 +2,6 @@
 # (c) 2017 Ribose, Inc. as unpublished work.
 #
 #
-
 require "digicert/base"
 require "digicert/findable"
 
@@ -29,12 +28,12 @@ module Digicert
       new(name_id: name_id, **attributes).create
     end
 
-    def reissue
-      Digicert::OrderReissuer.create(order_id: resource_id)
+    def reissue(attributes = {})
+      Digicert::OrderReissuer.create(order_id: resource_id, **attributes)
     end
 
-    def duplicate
-      Digicert::OrderDuplicator.create(order_id: resource_id)
+    def duplicate(attributes = {})
+      Digicert::OrderDuplicator.create(order_id: resource_id, **attributes)
     end
 
     def duplicate_certificates
@@ -53,6 +52,8 @@ module Digicert
 
     private
 
+    attr_reader :name_id
+
     def extract_local_attribute_ids
       @name_id = attributes.delete(:name_id)
     end
@@ -66,7 +67,7 @@ module Digicert
     end
 
     def certificate_klass
-      certificate_klass_hash[@name_id.to_sym] ||
+      certificate_klass_hash[name_id.to_sym] ||
         Digicert::SSLCertificate::SSLPlus
     end
 


### PR DESCRIPTION
In the Order's `#reissue` and `#duplicate` methods, there is no way to pass the updated attributes to the underlying resource, This commit changes this and add support for attributes that will be passed to the underlying resource if provided.