### PR TITLE
Download certificate to a specific path

### DIFF
--- a/README.md
+++ b/README.md
@@ -613,6 +613,18 @@ certificate = Digicert::CertificateDownloader.fetch(certificate_id)
 File.write("path_to_file_system/certificate.zip", certificate.body)
 ```
 
+Additionally, if you want the gem to handle the file writing then it also
+provides another helper interface `fetch_to_path`, and that will fetch the file
+content and write the content to supplied path.
+
+```ruby
+Digicert::CertificateDownloader.fetch_to_path(
+  certificate_id,
+  ext: "zip",
+  path: File.expand_path("./file/download/path"),
+)
+```
+
 #### Download a Certificate By Format
 
 This interface will return an SSL Certificate file from an order. The certificate

--- a/lib/digicert/certificate_downloader.rb
+++ b/lib/digicert/certificate_downloader.rb
@@ -16,6 +16,15 @@ module Digicert
       new(resource_id: certificate_id, platform: platform).fetch
     end
 
+    def self.fetch_to_path(certificate_id, path:, ext: "zip")
+      response = fetch(certificate_id)
+
+      if response.code.to_i == 200
+        filename = ["certificate", ext].join(".")
+        File.write([path, filename].join("/"), response.body)
+      end
+    end
+
     private
 
     attr_reader :format, :platform

--- a/spec/digicert/certificate_downloader_spec.rb
+++ b/spec/digicert/certificate_downloader_spec.rb
@@ -13,6 +13,22 @@ RSpec.describe Digicert::CertificateDownloader do
     end
   end
 
+  describe ".fetch_to_path" do
+    it "fetch and write that to a file" do
+      certificate_id = 123_456_789
+      allow(File).to receive(:write)
+      download_path = File.expand_path("../../tmp", __FILE__)
+
+      stub_digicert_certificate_download_by_platform(certificate_id)
+      Digicert::CertificateDownloader.fetch_to_path(
+        certificate_id, path: download_path, ext: "zip",
+      )
+
+      download_url = [download_path, "certificate.zip"].join("/")
+      expect(File).to have_received(:write).with(download_url, any_args)
+    end
+  end
+
   describe ".fetch_by_platform" do
     it "retrieves a certificate by specified platform" do
       platform = "apache"


### PR DESCRIPTION
This commit adds the interface to download to the certificate to user specified path, what it is doing is basically fetching the certificate content and write it to the user specified path and it also usages the `zip` default extension but it can be change by passing the `ext` key. Usage

```ruby
Digicert::CertificateDownloader.fetch_to_path(
  certificate_id,
  ext: "zip",
  path: File.expand_path("./file/download/path"),
)
```