### PR TITLE
Change response type to be configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,13 @@ with the following code
 ```ruby
 Digicert.configure do |config|
   config.api_key = "SECRET_DEV_API_KEY"
+
+  # Default response type is `object`, but you
+  # can configure it if necessary, and all the
+  # further response will be return as config
+  # supported options are `object`, `hash`
+  #
+  # config.response_type = :object
 end
 ```
 

--- a/lib/digicert/configuration.rb
+++ b/lib/digicert/configuration.rb
@@ -1,10 +1,21 @@
 module Digicert
   class Configuration
-    attr_accessor :api_key, :api_host, :base_path
+    attr_accessor :api_key, :api_host, :base_path, :response_type
 
     def initialize
       @api_host = "www.digicert.com"
       @base_path = "services/v2"
+      @response_type = :object
+    end
+
+    def response_klass
+      response_klasses[response_type.to_sym] || ResponseObject
+    end
+
+    private
+
+    def response_klasses
+      { hash: Hash, object: ResponseObject }
     end
   end
 end

--- a/lib/digicert/response.rb
+++ b/lib/digicert/response.rb
@@ -17,8 +17,12 @@ module Digicert
 
     def parse_response
       if response.body
-        JSON.parse(response.body, object_class: ResponseObject)
+        JSON.parse(response.body, object_class: response_object_klass)
       end
+    end
+
+    def response_object_klass
+      Digicert.configuration.response_klass
     end
   end
 

--- a/spec/digicert/config_spec.rb
+++ b/spec/digicert/config_spec.rb
@@ -25,6 +25,9 @@ RSpec.describe Digicert::Config do
 
       expect(Digicert.configuration.api_host).to eq(api_host)
       expect(Digicert.configuration.base_path).to eq(base_path)
+      expect(
+        Digicert.configuration.response_klass,
+      ).to eq(Digicert::ResponseObject)
     end
   end
 


### PR DESCRIPTION
Currently we are using `Digicert::ResponseObject` class to parse our existing API responses, which is basically a wrapper on top of the `OpenStruct`. Normally it's slower then ruby's basic type but the amount of data we would be dealing with is very small so it should not create any issues.

But let's be good, let's allow the user to configure the response type, so if they prefer then they can choose to parse their data in ruby's fastest `hash` type.

```ruby
Digicert.configure do |config|
  config.response_type = "hash"
end
```