### PR TITLE
Add `#fetch_to_path` for order instance

### DIFF
--- a/lib/digicert/order.rb
+++ b/lib/digicert/order.rb
@@ -50,6 +50,12 @@ module Digicert
       )
     end
 
+    def fetch_to_path(certificate_id, path:, ext: "zip")
+      Digicert::CertificateDownloader.fetch_to_path(
+        certificate_id, path: path, ext: ext,
+      )
+    end
+
     private
 
     attr_reader :name_id

--- a/spec/digicert/order_spec.rb
+++ b/spec/digicert/order_spec.rb
@@ -93,6 +93,21 @@ RSpec.describe Digicert::Order do
     end
   end
 
+  describe "#fetch_to_path" do
+    it "sends `fetch_to_path` message to the downloader" do
+      order_id = 123_456_789
+      certificate_id = 112358
+      allow(Digicert::CertificateDownloader).to receive(:fetch_to_path)
+
+      order = Digicert::Order.find(order_id)
+      order.fetch_to_path(certificate_id, path: "tmp", ext: "pem")
+
+      expect(Digicert::CertificateDownloader,).
+        to have_received(:fetch_to_path).
+        with(certificate_id, path: "tmp", ext: "pem")
+    end
+  end
+
   describe "#cancel" do
     it "sends the create methods to order cancellation" do
       order_id = 123_456_789


### PR DESCRIPTION
This commit adds the `#fetch_to_path` for order instance, so if you do not have the `certificate_id` but you only have the order id then you can use order instance to download the certificate to a specific path.

```ruby
order = Digicert::Order.find(order_id)
order.fetch_to_path(path: File.expand_path("tmp"), ext: "zip")
```

Ref #61