### PR TITLE
Add finder for the duplicate certificate

### DIFF
--- a/README.md
+++ b/README.md
@@ -561,6 +561,33 @@ Digicert::OrderDuplicator.create(
 )
 ```
 
+#### Find a Duplicate Certificate
+
+As of now, the Digicert API, does not have an easier way to find a duplicate
+certificate, as the certificate duplication returns existing `order_id` with a
+`request` node which only has an `id`.
+
+So to find out a duplicate certificate, we need to retrieve the details for that
+specific request and from that response retrieve the `date_created` for the
+duplicate certificate and then use that `date_created` to find out the correct
+certificate from the duplications of that specific order.
+
+This requires lots of work, so this following interface will do all of its
+underlying tasks, and all we need to do is pass the requests id that we will
+have form the certificate duplication.
+
+```ruby
+# Duplicate an existing certificate order
+#
+order = Digicert::Order.find(order_id)
+duplicate_order = order.duplicate
+
+# Use the request id to find out the certificate
+#
+request_id = duplicate_order.requests.first.id
+Digicert::DuplicateCertificateFinder.find_by(request_id: request_id)
+```
+
 #### List Duplicate Certificates
 
 Use this interface to view all duplicate certificates for an order.

--- a/lib/digicert.rb
+++ b/lib/digicert.rb
@@ -18,6 +18,7 @@ require "digicert/order_duplicator"
 require "digicert/duplicate_certificate"
 require "digicert/order_cancellation"
 require "digicert/expiring_order"
+require "digicert/duplicate_certificate_finder"
 
 module Digicert
 end

--- a/lib/digicert/duplicate_certificate_finder.rb
+++ b/lib/digicert/duplicate_certificate_finder.rb
@@ -1,0 +1,42 @@
+module Digicert
+  class DuplicateCertificateFinder
+    def initialize(reqeust_id:)
+      @reqeust_id = reqeust_id
+    end
+
+    def find
+      certificate_by_date_created
+    end
+
+    def self.find_by(reqeust_id:)
+      new(reqeust_id: reqeust_id).find
+    end
+
+    private
+
+    attr_reader :reqeust_id
+
+    def certificate_by_date_created
+      certificates_by_date_created.first
+    end
+
+    def certificates_by_date_created
+      duplicate_certificates.select do |certificate|
+        certificate.date_created == reqeust_created_at
+      end
+    end
+
+    def duplicate_certificates
+      @duplicate_certificates ||=
+        Digicert::DuplicateCertificate.all(order_id: reqeust.order.id)
+    end
+
+    def reqeust_created_at
+      reqeust.order.certificate.date_created
+    end
+
+    def reqeust
+      @reqeust ||= Digicert::CertificateRequest.fetch(reqeust_id)
+    end
+  end
+end

--- a/spec/digicert/duplicate_certificate_finder_spec.rb
+++ b/spec/digicert/duplicate_certificate_finder_spec.rb
@@ -1,0 +1,27 @@
+require "spec_helper"
+
+RSpec.describe Digicert::DuplicateCertificateFinder do
+  describe ".find" do
+    it "finds the duplicate certificate" do
+      reqeust_id = 123_456_789
+
+      stub_digicert_certificate_request_fetch_api(reqeust_id)
+      stub_digicert_order_duplications_api(order_id)
+
+      certificate = Digicert::DuplicateCertificateFinder.find_by(
+        reqeust_id: reqeust_id,
+      )
+
+      expect(certificate.id).not_to be_nil
+    end
+  end
+
+  def order_id
+    # Fetching an existing reqeust returns the fixtures file we
+    # wrote as certificate_request.json, and that order_id is
+    # being used to fetched the duplications, so for this use
+    # case let's keep it simple and hardcode the value for now
+    #
+    @order_id ||= 542757
+  end
+end

--- a/spec/fixtures/order_duplications.json
+++ b/spec/fixtures/order_duplications.json
@@ -37,7 +37,7 @@
         "subdomain.digicert.com"
       ],
       "status": "approved",
-      "date_created": "2014-08-19T18:16:07+00:00",
+      "date_created": "2014-12-04T20:32:59+00:00",
       "valid_from": "2014-08-19",
       "valid_till": "2015-08-24",
       "csr": "------ [CSR HERE] ------",


### PR DESCRIPTION
As of now, the Digicert API does not have an easier way to find a duplicate certificate, the certificate duplication returns existing `order_id` with a `request` node which only has an `id`.

So to find out a duplicate certificate, we need to retrieve the request details first and then use the `date_created` for that certificate to find out from all of the certificate duplications

This requires lots of work, so this following interface will do all of its underlying tasks, and all we need to do is pass the requests id that we will have form the certificate duplication.

```ruby
order = Digicert::Order.find(order_id)
duplicate_order = order.duplicate

request_id = duplicate_order.requests.first.id
Digicert::DuplicateCertificateFinder.find_by(request_id: request_id)
```