### PR TITLE
Add interface to revoke a certificate

### DIFF
--- a/README.md
+++ b/README.md
@@ -683,6 +683,14 @@ certificate = Digicert::CertificateDownloader.fetch_by_platform(
 )
 ```
 
+#### Revoke a Certificate
+
+This interface will revoke a previously issued SSL Certificate.
+
+```ruby
+Digicert::Certificate.revoke(certificate_id, comments: "Your comment")
+```
+
 ## Play Box
 
 The API Play Box provides an interactive console so we can easily test out the

--- a/lib/digicert.rb
+++ b/lib/digicert.rb
@@ -19,6 +19,7 @@ require "digicert/duplicate_certificate"
 require "digicert/order_cancellation"
 require "digicert/expiring_order"
 require "digicert/duplicate_certificate_finder"
+require "digicert/certificate"
 
 module Digicert
 end

--- a/lib/digicert/certificate.rb
+++ b/lib/digicert/certificate.rb
@@ -1,0 +1,25 @@
+require "digicert/base"
+
+module Digicert
+  class Certificate < Digicert::Base
+    extend Digicert::Findable
+
+    def revoke
+      Digicert::Request.new(:put, revocation_path, attributes).parse
+    end
+
+    def self.revoke(certificate_id, attributes = {})
+      new(attributes.merge(resource_id: certificate_id)).revoke
+    end
+
+    private
+
+    def resource_path
+      "certificate"
+    end
+
+    def revocation_path
+      [resource_path, resource_id, "revoke"].join("/")
+    end
+  end
+end

--- a/spec/digicert/certificate_spec.rb
+++ b/spec/digicert/certificate_spec.rb
@@ -1,0 +1,28 @@
+require "spec_helper"
+
+RSpec.describe Digicert::Certificate do
+  describe ".find" do
+    it "creates a certificate instance" do
+      certificate_id = 123_456_789
+      certificate = Digicert::Certificate.find(certificate_id)
+
+      expect(certificate.class).to eq(Digicert::Certificate)
+    end
+  end
+
+  describe "#revoke" do
+    it "revokes an existing certificate" do
+      certificate_id = 123_456_789
+      comments = "I no longer need this cert."
+      stub_digicert_certificate_revoke_api(certificate_id, comments: comments)
+
+      revocation = Digicert::Certificate.revoke(
+        certificate_id, comments: comments,
+      )
+
+      expect(revocation.id).not_to be_nil
+      expect(revocation.type).to eq("revoke")
+      expect(revocation.status).to eq("pending")
+    end
+  end
+end

--- a/spec/fixtures/certificate_revoked.json
+++ b/spec/fixtures/certificate_revoked.json
@@ -1,0 +1,13 @@
+{
+  "id": 1,
+  "date": "2016-02-10T17:06:15+00:00",
+  "type": "revoke",
+  "status": "pending",
+  "requester": {
+    "id": 242140,
+    "first_name": "Jack",
+    "last_name": "White",
+    "email": "j.white@fakeaddy.com"
+  },
+  "comments": "Revoked via API!"
+}

--- a/spec/support/fake_digicert_api.rb
+++ b/spec/support/fake_digicert_api.rb
@@ -230,6 +230,16 @@ module Digicert
       )
     end
 
+    def stub_digicert_certificate_revoke_api(id, attributes)
+      stub_api_response(
+        :put,
+        ["certificate", id, "revoke"].join("/"),
+        data: attributes,
+        filename: "certificate_revoked",
+        status: 201,
+      )
+    end
+
     def stub_digicert_certificate_download_by_format(id, format)
       stub_api_response_with_io(
         :get,


### PR DESCRIPTION
This commit adds the interface to revoke a previously issued SSL Certificate using the Digicert Certificate Management API.

```ruby
Digicert::Certificate.revoke(
  certificate_id, comments: "Your comments for revocation",
)
```