### PR TITLE
Add `download` to certificate instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -645,6 +645,11 @@ certificate = Digicert::CertificateDownloader.fetch(certificate_id)
 # write to content to somewhere in your filesystem.
 #
 File.write("path_to_file_system/certificate.zip", certificate.body)
+
+# Alaternative to fetch it through certificate instance
+#
+certificate = Digicert::Certificate.find(certificate_id)
+certificate_content_object = certificate.download
 ```
 
 Additionally, if you want the gem to handle the file writing then it also
@@ -670,6 +675,11 @@ to write that as zip archive.
 Digicert::CertificateDownloader.fetch_by_format(
   certificate_id, format: format,
 )
+
+# Alternative using the certificate instance
+#
+certificate = Digicert::Certificate.find(certificate_id)
+certificate_content_object = certificate.download(format: format)
 ```
 
 #### Download a Certificate By Platform
@@ -681,6 +691,11 @@ platform specified.
 certificate = Digicert::CertificateDownloader.fetch_by_platform(
   certificate_id, platform: "apache",
 )
+
+# Alternative using the certificate instance
+#
+certificate = Digicert::Certificate.find(certificate_id)
+certificate_content_object = certificate.download(platform: "apache")
 ```
 
 #### Revoke a Certificate

--- a/lib/digicert/certificate.rb
+++ b/lib/digicert/certificate.rb
@@ -4,6 +4,10 @@ module Digicert
   class Certificate < Digicert::Base
     extend Digicert::Findable
 
+    def download(attributes = {})
+      new_downloader(attributes).fetch
+    end
+
     def revoke
       Digicert::Request.new(:put, revocation_path, attributes).parse
     end
@@ -13,6 +17,12 @@ module Digicert
     end
 
     private
+
+    def new_downloader(attributes)
+      Digicert::CertificateDownloader.new(
+        attributes.merge(resource_id: resource_id),
+      )
+    end
 
     def resource_path
       "certificate"

--- a/spec/digicert/certificate_spec.rb
+++ b/spec/digicert/certificate_spec.rb
@@ -10,6 +10,44 @@ RSpec.describe Digicert::Certificate do
     end
   end
 
+  describe "#download" do
+    context "when format specified" do
+      it "fetches the certificate using the format" do
+        certificate_id = 123_456_789
+        certificate = Digicert::Certificate.find(certificate_id)
+        expected_hash = { resource_id: certificate_id, format: "zip" }
+
+        allow(
+          Digicert::CertificateDownloader,
+        ).to receive_message_chain(:new, :fetch)
+
+        certificate.download(format: "zip")
+
+        expect(
+          Digicert::CertificateDownloader,
+        ).to have_received(:new).with(expected_hash)
+      end
+    end
+
+    context "when platform specified" do
+      it "fetches the certificate using the platfrom" do
+        certificate_id = 123_456_789
+        certificate = Digicert::Certificate.find(certificate_id)
+        expected_hash = { resource_id: certificate_id, platform: "apache"}
+
+        allow(
+          Digicert::CertificateDownloader,
+        ).to receive_message_chain(:new, :fetch)
+
+        certificate.download(platform: "apache")
+
+        expect(
+          Digicert::CertificateDownloader,
+        ).to have_received(:new).with(expected_hash)
+      end
+    end
+  end
+
   describe "#revoke" do
     it "revokes an existing certificate" do
       certificate_id = 123_456_789


### PR DESCRIPTION
#This commit adds the `#download` to certificate instance, so now we can download any certificate using a certificate instance. It also supports one additional hash and based on the key specified it'll download the certificate using that `platform` or `format`

```ruby
certificate = Digicert::Certificate.find(certificate_id)

# Download the certificate in order specified format
certificate_content_object = certificate.download

# Download certificate in a specific format
certificate_content_object = certificate.download(format: "zip")

# Download certificate by a specific platform
certificate_content_object = certificate.download(platform: "apache")
```