### PR TITLE
Add `#download_to_path` to certificate

### DIFF
--- a/README.md
+++ b/README.md
@@ -661,7 +661,13 @@ Digicert::CertificateDownloader.fetch_to_path(
   certificate_id,
   ext: "zip",
   path: File.expand_path("./file/download/path"),
+  **other_attributes_hash_like_platform_or_format,
 )
+
+# Alternative through a certificate instance
+#
+certificate = Digicert::Certificate.find(certificate_id)
+certificate.download_to_path(path: "file/path", ext: "zip", format: "zip")
 ```
 
 #### Download a Certificate By Format

--- a/lib/digicert/certificate.rb
+++ b/lib/digicert/certificate.rb
@@ -16,6 +16,11 @@ module Digicert
       new(attributes.merge(resource_id: certificate_id)).revoke
     end
 
+    def download_to_path(path:, ext: "zip", **attributes)
+      new_downloader(attributes.merge(resource_id: resource_id)).
+        fetch_to_path(path: path, extension: ext)
+    end
+
     private
 
     def new_downloader(attributes)

--- a/spec/digicert/certificate_downloader_spec.rb
+++ b/spec/digicert/certificate_downloader_spec.rb
@@ -16,8 +16,8 @@ RSpec.describe Digicert::CertificateDownloader do
   describe ".fetch_to_path" do
     it "fetch and write that to a file" do
       certificate_id = 123_456_789
-      allow(File).to receive(:write)
-      download_path = File.expand_path("../../tmp", __FILE__)
+      allow(File).to receive(:open)
+      download_path = File.expand_path("../../../tmp", __FILE__)
 
       stub_digicert_certificate_download_by_platform(certificate_id)
       Digicert::CertificateDownloader.fetch_to_path(
@@ -25,7 +25,7 @@ RSpec.describe Digicert::CertificateDownloader do
       )
 
       download_url = [download_path, "certificate.zip"].join("/")
-      expect(File).to have_received(:write).with(download_url, any_args)
+      expect(File).to have_received(:open).with(download_url, "w")
     end
   end
 

--- a/spec/digicert/certificate_spec.rb
+++ b/spec/digicert/certificate_spec.rb
@@ -48,6 +48,27 @@ RSpec.describe Digicert::Certificate do
     end
   end
 
+  describe "#download_to_path" do
+    it "downloads and wrtites the certificate to the path" do
+      certificate_id = 123_456_789
+      certificate = Digicert::Certificate.find(certificate_id)
+      allow(File).to receive(:open)
+
+      download_to_path_attributes = {
+        ext: "zip",
+        path: File.expand_path("../../../tmp", __FILE__),
+      }
+
+      stub_digicert_certificate_download_by_platform(certificate_id)
+      certificate.download_to_path(download_to_path_attributes)
+
+      download_url =
+        [download_to_path_attributes[:path], "certificate.zip"].join("/")
+
+      expect(File).to have_received(:open).with(download_url, "w")
+    end
+  end
+
   describe "#revoke" do
     it "revokes an existing certificate" do
       certificate_id = 123_456_789


### PR DESCRIPTION
This commit adds the `download_to_path` for certificate instance, so now we can download an existing certificate to a specific path using the certificate instance. This also changes on some existing downloader interface so now the `fetch_to_path` supports additional hash key to specify `platform` or `format`.

```ruby
certificate = Digicert::Certificate.find(certificate_id)
certificate.download_to_path(
  platform: "apache",
  path: File.expand_path("./tmp"),
  ext: "zip",
)
```