### PR TITLE
Do not expose the internal implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -640,7 +640,7 @@ uses the platform specified by the order.
 # want to write it to your filesystem or directly upload it to
 # your host, and the contents it returns is `zip` archieve.
 #
-certificate = Digicert::CertificateDownloader.fetch(certificate_id)
+certificate = Digicert::CertificateDownloader.fetch(certificate_id, **attributes)
 
 # write to content to somewhere in your filesystem.
 #

--- a/lib/digicert/certificate.rb
+++ b/lib/digicert/certificate.rb
@@ -5,7 +5,7 @@ module Digicert
     extend Digicert::Findable
 
     def download(attributes = {})
-      new_downloader(attributes).fetch
+      certificate_downloader.fetch(resource_id, attributes)
     end
 
     def revoke
@@ -17,17 +17,12 @@ module Digicert
     end
 
     def download_to_path(path:, ext: "zip", **attributes)
-      new_downloader(attributes.merge(resource_id: resource_id)).
-        fetch_to_path(path: path, extension: ext)
+      certificate_downloader.fetch_to_path(
+        resource_id, attributes.merge(path: path, ext: ext),
+      )
     end
 
     private
-
-    def new_downloader(attributes)
-      Digicert::CertificateDownloader.new(
-        attributes.merge(resource_id: resource_id),
-      )
-    end
 
     def resource_path
       "certificate"
@@ -35,6 +30,10 @@ module Digicert
 
     def revocation_path
       [resource_path, resource_id, "revoke"].join("/")
+    end
+
+    def certificate_downloader
+      Digicert::CertificateDownloader
     end
   end
 end

--- a/lib/digicert/certificate_downloader.rb
+++ b/lib/digicert/certificate_downloader.rb
@@ -2,8 +2,6 @@ require "digicert/base"
 
 module Digicert
   class CertificateDownloader < Digicert::Base
-    include Digicert::Actions::Fetch
-
     def fetch
       Digicert::Request.new(:get, certificate_download_path).run
     end
@@ -12,12 +10,16 @@ module Digicert
       download_to_path(path: path, extension: extension)
     end
 
+    def self.fetch(certificate_id, attributes = {})
+      new(attributes.merge(resource_id: certificate_id)).fetch
+    end
+
     def self.fetch_by_format(certificate_id, format:)
-      new(resource_id: certificate_id, format: format).fetch
+      fetch(certificate_id, format: format)
     end
 
     def self.fetch_by_platform(certificate_id, platform:)
-      new(resource_id: certificate_id, platform: platform).fetch
+      fetch(certificate_id, platform: platform)
     end
 
     def self.fetch_to_path(certificate_id, path:, ext: "zip", **attributes)

--- a/spec/digicert/certificate_downloader_spec.rb
+++ b/spec/digicert/certificate_downloader_spec.rb
@@ -4,9 +4,12 @@ RSpec.describe Digicert::CertificateDownloader do
   describe ".fetch" do
     it "retrives the certificate contents" do
       certificate_id = 123_456_789
+      platform = "apache"
+      stub_digicert_certificate_download_by_platform(certificate_id, platform)
 
-      stub_digicert_certificate_download_by_platform(certificate_id)
-      certificate = Digicert::CertificateDownloader.fetch(certificate_id)
+      certificate = Digicert::CertificateDownloader.fetch(
+        certificate_id, platform: platform,
+      )
 
       expect(certificate.code.to_i).to eq(200)
       expect_certficate_to_be_a_zip_archieve(certificate)

--- a/spec/digicert/certificate_spec.rb
+++ b/spec/digicert/certificate_spec.rb
@@ -15,17 +15,13 @@ RSpec.describe Digicert::Certificate do
       it "fetches the certificate using the format" do
         certificate_id = 123_456_789
         certificate = Digicert::Certificate.find(certificate_id)
-        expected_hash = { resource_id: certificate_id, format: "zip" }
-
-        allow(
-          Digicert::CertificateDownloader,
-        ).to receive_message_chain(:new, :fetch)
+        allow(Digicert::CertificateDownloader).to receive(:fetch)
 
         certificate.download(format: "zip")
 
         expect(
           Digicert::CertificateDownloader,
-        ).to have_received(:new).with(expected_hash)
+        ).to have_received(:fetch).with(certificate_id, format: "zip")
       end
     end
 
@@ -33,17 +29,13 @@ RSpec.describe Digicert::Certificate do
       it "fetches the certificate using the platfrom" do
         certificate_id = 123_456_789
         certificate = Digicert::Certificate.find(certificate_id)
-        expected_hash = { resource_id: certificate_id, platform: "apache"}
-
-        allow(
-          Digicert::CertificateDownloader,
-        ).to receive_message_chain(:new, :fetch)
+        allow(Digicert::CertificateDownloader).to receive(:fetch)
 
         certificate.download(platform: "apache")
 
         expect(
           Digicert::CertificateDownloader,
-        ).to have_received(:new).with(expected_hash)
+        ).to have_received(:fetch).with(certificate_id, platform: "apache")
       end
     end
   end


### PR DESCRIPTION
If we want to use the current `Digicert::CertificateDownloader` form any other classes then we need to know too much about the internal implementation, like how to construct a new object, use its instance method to `fetch` or `fetch_to_path` or any other behavior where we have clearly defined class methods but there are some limitations

This commit fix these limitations for the class methods, so now we can replace the certificate instance methods to use these instead of dealing with downloaders internal implementation.