### PR TITLE
Extract `Digicert::Request` reference to base

### DIFF
--- a/lib/digicert/base.rb
+++ b/lib/digicert/base.rb
@@ -27,5 +27,9 @@ module Digicert
       @query_params = attributes.delete(:params)
       @resource_id = attributes.delete(:resource_id)
     end
+
+    def request_klass
+      Digicert::Request
+    end
   end
 end

--- a/lib/digicert/certificate.rb
+++ b/lib/digicert/certificate.rb
@@ -9,7 +9,7 @@ module Digicert
     end
 
     def revoke
-      Digicert::Request.new(:put, revocation_path, attributes).parse
+      request_klass.new(:put, revocation_path, attributes).parse
     end
 
     def self.revoke(certificate_id, attributes = {})

--- a/lib/digicert/certificate_downloader.rb
+++ b/lib/digicert/certificate_downloader.rb
@@ -3,7 +3,7 @@ require "digicert/base"
 module Digicert
   class CertificateDownloader < Digicert::Base
     def fetch
-      Digicert::Request.new(:get, certificate_download_path).run
+      request_klass.new(:get, certificate_download_path).run
     end
 
     def fetch_to_path(path:, extension: "zip")

--- a/lib/digicert/domain.rb
+++ b/lib/digicert/domain.rb
@@ -10,13 +10,13 @@ module Digicert
     include Digicert::Actions::Create
 
     def activate
-      Digicert::Request.new(
+      request_klass.new(
         :put, [resource_path, resource_id, "activate"].join("/"),
       ).parse
     end
 
     def deactivate
-      Digicert::Request.new(
+      request_klass.new(
         :put, [resource_path, resource_id, "deactivate"].join("/"),
       ).parse
     end

--- a/lib/digicert/order_cancellation.rb
+++ b/lib/digicert/order_cancellation.rb
@@ -3,7 +3,7 @@ require "digicert/base"
 module Digicert
   class OrderCancellation < Digicert::Base
     def create
-      Digicert::Request.new(
+      request_klass.new(
         :put, resource_path, default_attributes.merge(attributes),
       ).run
     end


### PR DESCRIPTION
We extracted pretty much most of the actions in separated modules, but there are still some use case scenario where we need to create a new `Digicert::Request` instance and invoke the public API. But this creates some sort of coupling and it might make it harder in the long run.

This commit extract the `Digicert::Request` reference to the base class and expose it as a `request_klass`, so if we need to change then it would be the only place that will require changes.