### PR TITLE
Add error handling for invalid response

### DIFF
--- a/lib/digicert/errors.rb
+++ b/lib/digicert/errors.rb
@@ -1,0 +1,30 @@
+require "digicert/errors/request_error"
+require "digicert/errors/forbidden"
+require "digicert/errors/server_error"
+require "digicert/errors/unauthorized"
+
+module Digicert
+  module Errors
+    def self.server_errors
+      [
+        OpenSSL::SSL::SSLError,
+        Errno::ETIMEDOUT,
+        Errno::EHOSTUNREACH,
+        Errno::ENETUNREACH,
+        Errno::ECONNRESET,
+        Net::OpenTimeout,
+        SocketError,
+        Net::HTTPServerError
+      ]
+    end
+
+    def self.error_klass_for(response)
+      case response
+      when *server_errors then Errors::ServerError
+      when Net::HTTPUnauthorized then Errors::Unauthorized
+      when Net::HTTPForbidden then Errors::Forbidden
+      else Errors::RequestError
+      end
+    end
+  end
+end

--- a/lib/digicert/errors/forbidden.rb
+++ b/lib/digicert/errors/forbidden.rb
@@ -1,0 +1,9 @@
+module Digicert
+  module Errors
+    class Forbidden < RequestError
+      def explanation
+        "A request to Digicert API was considered forbidden by the server"
+      end
+    end
+  end
+end

--- a/lib/digicert/errors/request_error.rb
+++ b/lib/digicert/errors/request_error.rb
@@ -1,0 +1,15 @@
+module Digicert
+  module Errors
+    class RequestError < StandardError
+      def message
+        explanation
+      end
+
+      def explanation
+        "A request to Digicert API failed"
+      end
+    end
+  end
+
+  Error = Errors::RequestError
+end

--- a/lib/digicert/errors/server_error.rb
+++ b/lib/digicert/errors/server_error.rb
@@ -1,0 +1,9 @@
+module Digicert
+  module Errors
+    class ServerError < RequestError
+      def explanation
+        "A request to Digicert API caused an unexpected server error"
+      end
+    end
+  end
+end

--- a/lib/digicert/errors/unauthorized.rb
+++ b/lib/digicert/errors/unauthorized.rb
@@ -1,0 +1,9 @@
+module Digicert
+  module Errors
+    class Unauthorized < RequestError
+      def explanation
+        "A request to Digicert API was sent without a valid authentication"
+      end
+    end
+  end
+end

--- a/spec/digicert/request_spec.rb
+++ b/spec/digicert/request_spec.rb
@@ -3,12 +3,23 @@ require "digicert/request"
 
 RSpec.describe Digicert::Request do
   describe "#run" do
-    it "retrieves a resource via a specified http verb" do
-      stub_ping_reqeust_via_get
-      response = Digicert::Request.new(:get, "ping").run
+    context "with 2xx response" do
+      it "retrieves a resource via a specified http verb" do
+        stub_ping_reqeust_via_get
+        response = Digicert::Request.new(:get, "ping").run
 
-      expect(response.code.to_i).to eq(200)
-      expect(response.class).to eq(Net::HTTPOK)
+        expect(response.code.to_i).to eq(200)
+        expect(response.class).to eq(Net::HTTPOK)
+      end
+    end
+
+    context "with 4xx, 5xx responses" do
+      it "raises the proper response error" do
+        stub_invalid_ping_reqeust_via_get
+        request = Digicert::Request.new(:get, "ping")
+
+        expect{ request.run }.to raise_error(Digicert::Errors::ServerError)
+      end
     end
   end
 
@@ -28,5 +39,9 @@ RSpec.describe Digicert::Request do
     # reponse with an identical json file that can be found in `fixtures`
     #
     stub_api_response(:get, "ping", filename: "ping")
+  end
+
+  def stub_invalid_ping_reqeust_via_get
+    stub_api_response(:get, "ping", filename: "orders", status: 500)
   end
 end


### PR DESCRIPTION
As of now, we were responding with `net/http`'s default errors, but this commit adds the custom errors, so whenever there is an invalid response then it will raise digicert's custom errors so developer can act properly.