### PR TITLE
Add instruction to generate the doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -764,6 +764,35 @@ Start playing with it.
 Digicert::Product.all
 ```
 
+### Generate Docs
+
+We've used some standard to write this usages guide and the gem, so if we want
+then we can generate a pretty formatted doc using [YARD](http://yardoc.org/).
+For simplicity we did not add the `doc` in this repo, but please follow the
+following steps to generate the updated doc.
+
+Install `yard`
+
+```sh
+gem install yard
+```
+
+Generate the documentation
+
+```sh
+
+# If you want to see what's available then
+# please use yard --help
+#
+yard doc
+```
+
+Open the doc in the browser
+
+```sh
+open doc/index.html
+```
+
 ## Contributing
 
 First, thank you for contributing! We love pull requests from everyone. By


### PR DESCRIPTION
Once we have made this gem public then we can use `Rubydoc.info` to generate the documentation, but as long as we are for internal use then we might need a better way to generate the updated doc.

This commit adds the documentation generation instructions, so our developer can easily generate one whenever necessary.