### PR TITLE
Add container retrieval request specs

### DIFF
--- a/spec/requests/container_management_spec.rb
+++ b/spec/requests/container_management_spec.rb
@@ -13,6 +13,15 @@ RSpec.describe "Container Management" do
     end
   end
 
+  describe "fetching a container details", api_call: true do
+    it "retrieves the details for a container" do
+      container = Digicert::Container.fetch(container_id)
+
+      expect(container.is_active).to eq(true)
+      expect(container.name).to eq("Ribose Inc.")
+    end
+  end
+
   def container_id
     @container_id ||= ENV["DIGICERT_CONTAINER_ID"]
   end


### PR DESCRIPTION
This commit adds the request specs to verify the container fetch interface is working as expected, and we are using our hard coded value to verify our company name.