### PR TITLE
Add organization retrieval request specs

### DIFF
--- a/spec/requests/organization_management_spec.rb
+++ b/spec/requests/organization_management_spec.rb
@@ -1,0 +1,22 @@
+require "spec_helper"
+
+RSpec.describe "Organization Management" do
+  describe "fetching an organization", api_call: true do
+    it "fetches the organization details" do
+      organizations = Digicert::Organization.all
+      organization = Digicert::Organization.fetch(organizations.first.id)
+
+      expect(organization.name).to eq("Ribose Inc.")
+      expect(organization.id).to eq(organization_id)
+      expect(organization.container.id).to eq(container_id)
+    end
+  end
+
+  def container_id
+    @container_id ||= ENV["DIGICERT_CONTAINER_ID"].to_i
+  end
+
+  def organization_id
+    @organization_id ||= ENV["DIGICERT_ORGANIZATION_ID"].to_i
+  end
+end


### PR DESCRIPTION
This commit adds the request specs to fetch an organization. It usages `all` interface to fetch all the organization and once it has the list then it use the `.fetch` to retrieve the details for the first organization, and that way it verifies both interfaces