### PR TITLE
Add request spec to retrieve an order

### DIFF
--- a/spec/requests/order_management_spec.rb
+++ b/spec/requests/order_management_spec.rb
@@ -1,0 +1,24 @@
+require "spec_helper"
+
+RSpec.describe "Order Management" do
+  describe "retrieving a certificate order", api_call: true do
+    it "retrieves the details for a specific certificate order" do
+      order = Digicert::Order.fetch(order_id)
+
+      expect(order.product_name_id).to eq("ssl_plus")
+      expect(order.certificate.common_name).to eq("ribosetest.com")
+      expect(order.organization.display_name).to eq("Ribose Inc.")
+    end
+  end
+
+  def order_id
+    @order_id ||= orders.first.id
+  end
+
+  def orders
+    # We are intentionally making this API call to ensure
+    # the `Order.all` interface is working as it should have.
+    #
+    @orders ||= Digicert::Order.all
+  end
+end


### PR DESCRIPTION
This commit adds the request specs for `order` retrieval interfaces. This usages the `.all` interface to list all the certificate orders, and then use the first `order_id` to retrieve the details using the `Digicert::Order.fetch` interface.