### PR TITLE
Add interface to list all containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,33 +50,24 @@ Digicert.configuration.api_key = "SECRET_DEV_API_KEY"
 
 ### Container
 
-#### List Container Templates
+Container is an Operational Division used to model your organizational
+structure. The features of the container you create are determined by
+its Container Template.
 
-Container Templates define a set of features that are available to a container.
-Use this interface to retrieve a list of the templates that are available to use
-to create child containers.
+#### List Containers
 
-```ruby
-Digicert::ContainerTemplate.all(container_id)
-```
+Use this interface to retrieve a list of existing containers.
 
-#### View a Container Template
-
-Use this interface to retrieve information about a specific container template,
-including which user access roles are available under this template.
+Note: This is an undocumented endpoint of the DigiCert Services API.
 
 ```ruby
-Digicert::ContainerTemplate.fetch(
-  template_id: template_id, container_id: container_id,
-)
+Digicert::Container.all
 ```
 
 #### Create a Container
 
-Container is an Operational Division used to model your organizational
-structure. The features of the container you create are determined by its
-Container Template. Use this interface to create new container, and this
-interface also expects us to provide `parent_container` along with the others
+Use this interface to create new container, and this interface also
+expects us to provide `parent_container` along with the others
 attributes as `container_id`.
 
 ```ruby
@@ -103,6 +94,30 @@ including its name, description, template, and parent container id.
 
 ```ruby
 Digicert::Container.fetch(container_id)
+```
+
+### Container Template
+
+Container Templates define a set of features that are available to a container.
+
+#### List Container Templates
+
+Use this interface to retrieve a list of the templates that are available to use
+to create child containers.
+
+```ruby
+Digicert::ContainerTemplate.all(container_id)
+```
+
+#### View a Container Template
+
+Use this interface to retrieve information about a specific container template,
+including which user access roles are available under this template.
+
+```ruby
+Digicert::ContainerTemplate.fetch(
+  template_id: template_id, container_id: container_id,
+)
 ```
 
 ### Organization

--- a/lib/digicert/container.rb
+++ b/lib/digicert/container.rb
@@ -2,6 +2,7 @@ require "digicert/base"
 
 module Digicert
   class Container < Digicert::Base
+    include Digicert::Actions::All
     include Digicert::Actions::Fetch
     include Digicert::Actions::Create
 

--- a/spec/digicert/container_spec.rb
+++ b/spec/digicert/container_spec.rb
@@ -1,6 +1,16 @@
 require "spec_helper"
 
 RSpec.describe Digicert::Container do
+  describe ".all" do
+    it "retrieves the list of containers" do
+      stub_digicert_container_list_api
+      containers = Digicert::Container.all
+
+      expect(containers.first.id).not_to be_nil
+      expect(containers.first.name).to eq("Ribose Inc.")
+    end
+  end
+
   describe ".create" do
     it "creates a new sub container" do
       stub_digicert_container_create_api(container_attributes)

--- a/spec/fixtures/containers.json
+++ b/spec/fixtures/containers.json
@@ -1,0 +1,14 @@
+{
+  "containers": [
+    {
+      "id": 123456,
+      "public_id": "vp1h1ou11h1h1h11o",
+      "name": "Ribose Inc.",
+      "parent_id": 0,
+      "template_id": 5,
+      "ekey": "ch23fafaahfha",
+      "has_logo": false,
+      "is_active": true
+    }
+  ]
+}

--- a/spec/requests/container_management_spec.rb
+++ b/spec/requests/container_management_spec.rb
@@ -23,6 +23,14 @@ RSpec.describe "Container Management" do
   end
 
   def container_id
-    @container_id ||= ENV["DIGICERT_CONTAINER_ID"]
+    @container_id ||= containers.first.id
+  end
+
+  def containers
+    # We are making this API call intentionally, this
+    # ensures the listing containers API is working as
+    # it should have as long as there are no errors.
+    #
+    @containers ||= Digicert::Container.all
   end
 end

--- a/spec/support/fake_digicert_api.rb
+++ b/spec/support/fake_digicert_api.rb
@@ -115,6 +115,12 @@ module Digicert
       )
     end
 
+    def stub_digicert_container_list_api
+      stub_api_response(
+        :get, "container", filename: "containers", status: 200,
+      )
+    end
+
     def stub_digicert_container_fetch_api(container_id)
       stub_api_response(
         :get, ["container", container_id].join("/"), filename: "container",


### PR DESCRIPTION
Digicert has one undocumented API endpoint, which is listing containers. This commit adds the interface to list all of the containers using Digicert API and it also updates the documentation to reflect this change. Usages.

```ruby
Digicert::Container.all
```