### PR TITLE
Fix `#initialize_http_header` related issue

### DIFF
--- a/lib/digicert/request.rb
+++ b/lib/digicert/request.rb
@@ -62,7 +62,7 @@ module Digicert
       URI::HTTPS.build(
         host: Digicert.configuration.api_host,
         path: digicert_api_path_with_base,
-        query: build_query_params,
+        query: build_query_params
       )
     end
 
@@ -77,9 +77,9 @@ module Digicert
     end
 
     def set_request_headers!(request)
-      request.initialize_http_header("Content-Type" => "application/json")
       request.initialize_http_header(
-        "X-DC-DEVKEY" => Digicert.configuration.api_key,
+        "Content-Type" => "application/json",
+        "X-DC-DEVKEY" => Digicert.configuration.api_key
       )
     end
 

--- a/spec/support/fake_digicert_api.rb
+++ b/spec/support/fake_digicert_api.rb
@@ -308,7 +308,10 @@ module Digicert
     end
 
     def api_key_header
-      { "X-DC-DEVKEY" => Digicert.configuration.api_key }
+      {
+        "Content-Type" => "application/json",
+        "X-DC-DEVKEY" => Digicert.configuration.api_key
+      }
     end
 
     def digicert_fixture(filename)


### PR DESCRIPTION
In the `Digicert::Request` we're using `#initialize_http_header` to set Dev API key and `Content-Type` header separately. But the way `#initialize_http_header`  every call to this method reset the header and only sets the provided has key values pair.

This was causing our `create` request to fail, as for the create request we need to specify the `content_type` with the `API Key`, but it was being overridden in the way it was.

This commit fixes this, Now all of our headers should have been setted up properly.

Source: https://github.com/ruby/ruby/blob/trunk/lib/net/http/header.rb#L14