### PR TITLE
Add a configurable application debugger

### DIFF
--- a/lib/digicert/configuration.rb
+++ b/lib/digicert/configuration.rb
@@ -1,15 +1,20 @@
 module Digicert
   class Configuration
-    attr_accessor :api_key, :api_host, :base_path, :response_type
+    attr_accessor :api_key, :api_host, :base_path, :response_type, :debug_mode
 
     def initialize
       @api_host = "www.digicert.com"
       @base_path = "services/v2"
       @response_type = :object
+      @debug_mode = false
     end
 
     def response_klass
       response_klasses[response_type.to_sym] || ResponseObject
+    end
+
+    def debug_mode?
+      debug_mode == true
     end
 
     private

--- a/lib/digicert/debugger.rb
+++ b/lib/digicert/debugger.rb
@@ -1,0 +1,34 @@
+module Digicert
+  class Debugger
+    def initialize(request:, response:)
+      @request = request
+      @response = response
+    end
+
+    def debug
+      puts "[API Reqeust Begin]".center(50, "=")
+      puts api_request_details
+      puts api_response_details
+      puts "[API Reqeust End]".center(50, "=")
+    end
+
+    private
+
+    attr_reader :request, :response
+
+    def api_request_details
+      uri = ["[URI]", request.method, request.uri].join(" ")
+      headers = "[Headers] " + request.to_hash.to_s
+      body = "[Request Body] " + request.body.to_json if request.body
+
+      [uri, headers, body].join("\n")
+    end
+
+    def api_response_details
+      response_object = "[Response] " + response.inspect
+      body = "[Response Body] " + response.body if response.body
+
+      [response_object, body].join("\n")
+    end
+  end
+end

--- a/spec/digicert/config_spec.rb
+++ b/spec/digicert/config_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe Digicert::Config do
 
       expect(Digicert.configuration.api_host).to eq(api_host)
       expect(Digicert.configuration.base_path).to eq(base_path)
+      expect(Digicert.configuration.debug_mode?).to be_falsey
       expect(
         Digicert.configuration.response_klass,
       ).to eq(Digicert::ResponseObject)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,6 +15,7 @@ RSpec.configure do |config|
 
   config.before :all do
     Digicert.configure do |digicert_config|
+      digicert_config.debug_mode = false
       digicert_config.api_key = ENV["SECRET_DEV_API_KEY"] || "SECRET_KEY"
     end
   end


### PR DESCRIPTION
We need to debug API request and Responses for different purpose, This commit adds a debugger that will log requests and responses details in the terminal. We have a added a config variable that can be use to turn the debug mode on or off, by default it will be off but we can turn that on by simply adding the `debug_mode` configuration in the initializer or any other file.

```ruby
Digicert.configure do |digicert_config|
  digicert_config.debug_mode = true
end

# Alternavtive, can be used from any file
Digicert.configuration.debug_mode = true
```