### PR TITLE
Add `san_names` support in CSR generation

### DIFF
--- a/digicert.gemspec
+++ b/digicert.gemspec
@@ -35,4 +35,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 12.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "webmock", "~> 2.0"
+  spec.add_development_dependency "r509", "~> 1.0"
 end

--- a/spec/requests/certificate_generation_spec.rb
+++ b/spec/requests/certificate_generation_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe "Certificate Generation" do
 
   def csr_content_for_ribosetest
     @csr_content ||= Digicert::CSRGenerator.generate(
-      domain: common_name, organization: ribose_inc,
+      common_name: common_name, organization: ribose_inc,
     )
   end
 

--- a/spec/requests/order_ssl_wildcard_spec.rb
+++ b/spec/requests/order_ssl_wildcard_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe "Order SSLWildcard" do
 
   def csr_content_for_ribosetest
     @csr_content ||= Digicert::CSRGenerator.generate(
-      domain: common_name, organization: ribose_inc,
+      common_name: common_name, organization: ribose_inc,
     )
   end
 end

--- a/spec/support/digicert_csr_generator.rb
+++ b/spec/support/digicert_csr_generator.rb
@@ -1,49 +1,44 @@
+require "r509"
+
 module Digicert
   class CSRGenerator
-    def initialize(domain:, organization:)
-      @domain_name = domain
+    def initialize(common_name:, organization:, san_names: [])
+      @common_name = common_name
+      @san_names = san_names
       @organization = organization
     end
 
     def generate
-      openssl_request_instance.to_s
+      create_r509_csr.to_s
     end
 
-    def self.generate(domain:, organization:)
-      new(domain: domain, organization: organization).generate
+    def self.generate(attributes)
+      new(attributes).generate
     end
 
     private
 
-    attr_reader :organization, :domain_name
+    attr_reader :organization, :common_name, :san_names
 
-    def openssl_request_instance
-      OpenSSL::X509::Request.new.tap do |reqeust|
-        reqeust.version = 0
-        reqeust.subject = openssl_name_instance
-        reqeust.public_key = rsa_key.public_key
-
-        reqeust.sign(rsa_key, OpenSSL::Digest::SHA1.new)
-      end
+    def create_r509_csr
+      R509::CSR.new(
+        key: rsa_key_file, subject: subject_items, san_names: san_names,
+      )
     end
 
-    def rsa_key
-      OpenSSL::PKey::RSA.new(File.read(rsa_key_file))
-    end
-
-    def openssl_name_instance
-      OpenSSL::X509::Name.new([
-        ["C",  organization.country, OpenSSL::ASN1::PRINTABLESTRING],
-        ["ST", organization.state,   OpenSSL::ASN1::PRINTABLESTRING],
-        ["L",  organization.city,    OpenSSL::ASN1::PRINTABLESTRING],
-        ["O",  organization.name,    OpenSSL::ASN1::UTF8STRING],
-        ["CN", domain_name, OpenSSL::ASN1::UTF8STRING],
-      ])
+    def subject_items
+      [
+        ["CN", common_name],
+        ["C",  organization.country],
+        ["ST", organization.state],
+        ["L",  organization.city],
+        ["O",  organization.name],
+      ]
     end
 
     def rsa_key_file
       rsa_key_path = "../../fixtures/rsa4096.key"
-      File.expand_path(rsa_key_path, __FILE__)
+      File.read(File.expand_path(rsa_key_path, __FILE__))
     end
   end
 end


### PR DESCRIPTION
This commit adds support for `san_names` in the CSR generation, it also adds `r509` as development dependency to minimize the ground work to use `openssl` directly.

Now we don't need to worry about sanitization or any other ground work that we were doing to generate a CSR using `openssl`, and it also seems pretty flexible so it would be easier to manage if we need to extend any of it's functionality.

Ref: http://www.rubydoc.info/gems/r509/
Discussion: PR #88 