### PR TITLE
Add `.find_by_object` interface to findable

### DIFF
--- a/lib/digicert/findable.rb
+++ b/lib/digicert/findable.rb
@@ -18,5 +18,16 @@ module Digicert
     def find(resource_id)
       new(resource_id: resource_id)
     end
+
+    # Find by object
+    #
+    # This `find_by_object` interface works more likely a wrapper
+    # around `find` interface, it expects the `object` to response
+    # to the `id` method. Then it delegates object initialization
+    # behavior to the `find` interface.
+    #
+    def find_by_object(object)
+      find(object.id)
+    end
   end
 end

--- a/spec/digicert/findable_spec.rb
+++ b/spec/digicert/findable_spec.rb
@@ -1,0 +1,19 @@
+require "spec_helper"
+require "digicert/base"
+
+RSpec.describe "Digicert::TestFindable" do
+  describe ".find_by_object" do
+    it "initialize an instnace using the object" do
+      findable_object = double("order", id: 123_456_789)
+      new_object = Digicert::TestFindable.find_by_object(findable_object)
+
+      expect(new_object.class).to eq(Digicert::TestFindable)
+    end
+  end
+
+  module Digicert
+    class TestFindable < Digicert::Base
+      extend Digicert::Findable
+    end
+  end
+end


### PR DESCRIPTION
This commit adds `find_by_object` method to the findable interface, so now if any class extends `findable` module then it will have 2 methods `find` and `find_by_object`, which can be use to initialize a new instance of the class.

The `find` interface expect us to provide the `resource_id`, and the `find_by_object` expect us to provide the `object` and it will extract the `resource_id` from that. Sample use cases.

```ruby
order = Digicert::Order.find_by_object(Digicert::Order.all.first)

# Duplicate the order
order.duplicate
```

Note: We are already extending this module in `Digicert::Order`, so it should already have this behavior, but if you need the instantiating behavior to any other class then please extend the `Digicert::Findable` module.