### PR TITLE
Add CSR generator to generate CSR on the fly

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,20 @@ Use this interface to retrieve a full set of details for a product.
 Digicert::Product.fetch(name_id)
 ```
 
+#### Generate the CSR content
+
+This interface will allow us to generate the CSR content on the fly, it will
+return the content that we can use for order creation.
+
+```ruby
+Digicert::CSRGenerator.generate(
+  common_name: "example.com",
+  san_names: ["example.com", "www.example.com"],
+  rsa_key: File.read("your_rsa_key_file_path"),
+  organization: Digicert::Organization.first,
+)
+```
+
 #### Create any type of order
 
 Use this interface to create a new order, this expect two arguments one is

--- a/digicert.gemspec
+++ b/digicert.gemspec
@@ -29,11 +29,12 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "r509", "~> 1.0"
+
   spec.add_development_dependency "pry"
   spec.add_development_dependency "dotenv"
   spec.add_development_dependency "bundler", "~> 1.14"
   spec.add_development_dependency "rake", "~> 12.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "webmock", "~> 2.0"
-  spec.add_development_dependency "r509", "~> 1.0"
 end

--- a/lib/digicert.rb
+++ b/lib/digicert.rb
@@ -6,6 +6,7 @@
 require "digicert/config"
 require "digicert/product"
 require "digicert/order"
+require "digicert/csr_generator"
 require "digicert/certificate_request"
 require "digicert/organization"
 require "digicert/container_template"

--- a/spec/digicert/csr_generator_spec.rb
+++ b/spec/digicert/csr_generator_spec.rb
@@ -1,0 +1,31 @@
+require "spec_helper"
+
+RSpec.describe Digicert::CSRGenerator do
+  describe ".generate" do
+    it "returns the generated csr content" do
+      csr = Digicert::CSRGenerator.generate(
+        rsa_key: rsa_key_content,
+        organization: ribose_inc,
+        common_name: "ribosetest.com",
+      )
+
+      expect(csr.start_with?("-----BEGIN CERTIFICATE REQUEST")).to be_truthy
+      expect(csr.end_with?("--END CERTIFICATE REQUEST-----\n")).to be_truthy
+    end
+  end
+
+  def rsa_key_content
+    rsa_key_path = "../../fixtures/rsa4096.key"
+    File.read(File.expand_path(rsa_key_path, __FILE__))
+  end
+
+  def ribose_inc
+    double(
+      "Digicert::Organization",
+      name: "Ribose Inc.",
+      city: "Wilmington",
+      state: "Delaware",
+      country: "us",
+    )
+  end
+end


### PR DESCRIPTION
This commit adds the `Digicert::CSRGenerator`, which can be used to generate a production ready CSR on the fly. It usages the `r509` in the underneath. It expects the basic attributes as a hash arguments

```ruby
Digicert::CSRGenerator.generate(
  rsa_key: rsa_key_file_content,
  common_name: "example.com",
  san_names: ["example.com", "www.example.com"],
  organization: Digicert::Organization.first,
)
```