### PR TITLE
Add response body with the raised errors

### DIFF
--- a/lib/digicert/errors/request_error.rb
+++ b/lib/digicert/errors/request_error.rb
@@ -1,12 +1,34 @@
+require "digicert/config"
+
 module Digicert
   module Errors
     class RequestError < StandardError
+      def initialize(msg = {})
+        @msg = msg
+        super msg
+      end
+
       def message
-        explanation
+        <<-MSG.gsub(/^ {8}/, '')
+        #{explanation}:
+        #{response_body}
+        MSG
       end
 
       def explanation
         "A request to Digicert API failed"
+      end
+
+      def kind
+        response_body.fetch("code", {})
+      end
+
+      private
+
+      attr_reader :msg
+
+      def response_body
+        JSON[msg] rescue {}
       end
     end
   end

--- a/lib/digicert/request.rb
+++ b/lib/digicert/request.rb
@@ -54,7 +54,7 @@ module Digicert
     end
 
     def raise_response_error
-      raise response_error
+      raise response_error, error_message
     end
 
     def net_http_options
@@ -98,6 +98,11 @@ module Digicert
 
     def response_error
       Digicert::Errors.error_klass_for(response)
+    end
+
+    def error_message
+      JSON(response.body)["errors"]
+    rescue response.inspect
     end
 
     def server_errors

--- a/spec/digicert/request_spec.rb
+++ b/spec/digicert/request_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Digicert::Request do
         stub_invalid_ping_request_via_get
         request = Digicert::Request.new(:get, "ping")
 
-        expect{ request.run }.to raise_error(Digicert::Errors::ServerError)
+        expect{ request.run }.to raise_error(/not_found\|route/)
       end
     end
   end
@@ -42,6 +42,6 @@ RSpec.describe Digicert::Request do
   end
 
   def stub_invalid_ping_request_via_get
-    stub_api_response(:get, "ping", filename: "orders", status: 500)
+    stub_api_response(:get, "ping", filename: "errors", status: 404)
   end
 end

--- a/spec/fixtures/errors.json
+++ b/spec/fixtures/errors.json
@@ -1,0 +1,6 @@
+{
+  "errors": {
+    "code": "not_found|route",
+    "message": "The specified route was not found."
+  }
+}


### PR DESCRIPTION
Currently we are only raising an error for any invalid response, but it is not that helpful sometime as we can't exactly see what is the response we got from API.

This commit changes this to support showing the response body, and it also parse the response body so the error instance will have the error type with proper message.