### PR TITLE
Request spec for client email security plus

### DIFF
--- a/spec/requests/order_client_email_security_plus_spec.rb
+++ b/spec/requests/order_client_email_security_plus_spec.rb
@@ -1,0 +1,38 @@
+require "spec_helper"
+
+RSpec.describe "Order client email security plus" do
+  describe "ordering client email security plus", api_call: true do
+    it "creates a new order for client email security plus" do
+      product_name_id = "email_security_plus"
+
+      # Reqeust a new email security plus using the order creation
+      # interface with `product_name_id` and required attributes
+      #
+      order_request = Digicert::Order.create(
+        product_name_id, order_attributes,
+      )
+
+      puts order_request
+    end
+  end
+
+  def ribose_inc
+    @ribose_inc ||= Digicert::Organization.all.first
+  end
+
+  def order_attributes
+    {
+      validity_years: 3,
+      certificate: certificate_attributes,
+      organization: { id: ribose_inc.id },
+    }
+  end
+
+  def certificate_attributes
+    {
+      common_name: "John Doe",
+      signature_hash: "sha256",
+      emails: ["johndoe@ribosetest.com"],
+    }
+  end
+end


### PR DESCRIPTION
This commit will adds the request specs for email security plus, but this seems to be causing the same issue as we have with the client premium certificate, I assume it could be something with the client certificate or something. @ronaldtse could you please check this one as well and let me know if there is any update.

```sh
bin/rspec --tag api_call spec/requests/order_client_email_security_plus_spec.rb
```

<img width="1279" alt="screenshot 2017-03-25 17 36 09" src="https://cloud.githubusercontent.com/assets/1220911/24321585/5376f7f8-1182-11e7-9764-8fa67fad6274.png">
