### PR TITLE
Prepare the gem for initial release

### DIFF
--- a/digicert.gemspec
+++ b/digicert.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.files         = `git ls-files`.split("\n")
   spec.test_files    = `git ls-files -- {spec}/*`.split("\n")
+  spec.required_ruby_version = Gem::Requirement.new(">= 2.1.9")
 
   spec.add_dependency "r509", "~> 1.0"
 

--- a/lib/digicert.rb
+++ b/lib/digicert.rb
@@ -1,7 +1,24 @@
-# Confidential and proprietary trade secret material of Ribose, Inc.
-# (c) 2017 Ribose, Inc. as unpublished work.
+#--
+# Copyright (c) 2017 Ribose Inc.
 #
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
 #
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+# ++
 
 require "digicert/config"
 require "digicert/product"

--- a/lib/digicert/order.rb
+++ b/lib/digicert/order.rb
@@ -1,7 +1,3 @@
-# Confidential and proprietary trade secret material of Ribose, Inc.
-# (c) 2017 Ribose, Inc. as unpublished work.
-#
-#
 require "digicert/base"
 require "digicert/findable"
 

--- a/lib/digicert/organization.rb
+++ b/lib/digicert/organization.rb
@@ -1,7 +1,3 @@
-# Confidential and proprietary trade secret material of Ribose, Inc.
-# (c) 2017 Ribose, Inc. as unpublished work.
-#
-#
 require "digicert/base"
 
 module Digicert

--- a/lib/digicert/version.rb
+++ b/lib/digicert/version.rb
@@ -1,7 +1,25 @@
-# Confidential and proprietary trade secret material of Ribose, Inc.
-# (c) 2017 Ribose, Inc. as unpublished work.
+#--
+# Copyright (c) 2017 Ribose Inc.
 #
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
 #
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+# ++
+
 module Digicert
-  VERSION = "0.1.0".freeze
+  VERSION = "0.1.1".freeze
 end


### PR DESCRIPTION
This commit prepares the for initial release, this also updates the licensing related comments with the correct type and this also sets the `2.1.9` as minimum version requirements for this gem.