### PR TITLE
Expose test stubs and helpers to the developer

### DIFF
--- a/lib/digicert.rb
+++ b/lib/digicert.rb
@@ -40,4 +40,7 @@ require "digicert/duplicate_certificate_finder"
 require "digicert/certificate"
 
 module Digicert
+  def self.root
+    File.dirname(__dir__)
+  end
 end

--- a/lib/digicert/rspec.rb
+++ b/lib/digicert/rspec.rb
@@ -1,0 +1,21 @@
+# Test Helpers for RSpec
+#
+# Actual API requests are slow and expensive and we try not to make actual
+# API request when possible. For most of our tests we mock the API call which
+# verifies the endpoint, http verb and headers and based on those it responses
+# with an identical fixture file.
+#
+# The main purpose of this file is to allow you to use our test helpers by
+# simplify adding this file to your application and then use the available
+# helper  method when necessary.
+#
+# Please check `spec/support` directory to see the available helper methods.
+#
+# We do not include this module with the gem by default, but you can do so
+# by adding `require "digicert/rspec"` on top of your `spec_helpe` file.
+#
+require File.join(Digicert.root, "spec/support/fake_digicert_api.rb")
+
+RSpec.configure do |config|
+  config.include Digicert::FakeDigicertApi
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,9 @@
 require "dotenv/load"
 require "webmock/rspec"
 require "bundler/setup"
+
 require "digicert"
+require "digicert/rspec"
 
 Dir["./spec/support/**/*.rb"].sort.each { |file| require file }
 
@@ -30,6 +32,4 @@ RSpec.configure do |config|
     Digicert.configuration.debug_mode = true
     WebMock.allow_net_connect!
   end
-
-  config.include Digicert::FakeDigicertApi
 end

--- a/spec/support/fake_digicert_api.rb
+++ b/spec/support/fake_digicert_api.rb
@@ -316,7 +316,7 @@ module Digicert
 
     def digicert_fixture(filename)
       file_name = [filename, "json"].join(".")
-      file_path = ["../../", "fixtures", file_name].join("/")
+      file_path = File.join(Digicert.root, "spec", "fixtures", file_name)
 
       File.read(File.expand_path(file_path, __FILE__))
     end


### PR DESCRIPTION
Actual API requests are slow and expensive and we try not to make actual API request when possible. For most of our tests we mock the API call which verifies the endpoint, http verb and headers, based on those we helpers responses with an identical fixture file.

We have been using it internally and now we want developer to have the option so they can test their application while using our gem.

This commit add a `digicert/rspec` file, so developer can require this one in their `spec_helper` to utilize all of our test helper