### PR TITLE
Add support for query params in orders

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,6 +517,13 @@ Use this interface to retrieve a list of all certificate orders.
 Digicert::Order.all
 ```
 
+This interface also supports query params like `limit`, `offset` and `sort`. We
+can use those to retrieve our desire orders.
+
+```ruby
+Digicert::Order.all(limit: 20, offset: 0, sort: 'date_created')
+```
+
 #### List of Email Validations
 
 Use this interface to view the status of all emails that require validation on a

--- a/lib/digicert/actions/all.rb
+++ b/lib/digicert/actions/all.rb
@@ -18,8 +18,8 @@ module Digicert
       end
 
       module ClassMethods
-        def all(filter_params = {})
-          new(params: filter_params).all
+        def all(query_params = {})
+          new(params: query_params).all
         end
       end
     end

--- a/spec/digicert/actions/all_spec.rb
+++ b/spec/digicert/actions/all_spec.rb
@@ -3,12 +3,26 @@ require "digicert/base"
 
 RSpec.describe "Digicert::Actions::ALL" do
   describe ".all" do
-    it "retrieves the list of resources" do
-      stub_digicert_organization_list_api
-      organizations = Digicert::TestAllAction.all
+    context "with out query param" do
+      it "retrieves the list of resources" do
+        stub_digicert_organization_list_api
+        organizations = Digicert::TestAllAction.all
 
-      expect(organizations.count).to eq(2)
-      expect(organizations.first.name).not_to be_nil
+        expect(organizations.count).to eq(2)
+        expect(organizations.first.name).not_to be_nil
+      end
+    end
+
+    context "with specificed query params" do
+      it "pass the params and retrieve the list of resources" do
+        query_params = { limit: 2, offset: 0, sort: "date_created" }
+
+        stub_digicert_organization_list_api(query_params)
+        organizations = Digicert::TestAllAction.all(query_params)
+
+        expect(organizations.count).to eq(2)
+        expect(organizations.first.name).not_to be_nil
+      end
     end
   end
 

--- a/spec/digicert/order_spec.rb
+++ b/spec/digicert/order_spec.rb
@@ -15,13 +15,27 @@ RSpec.describe Digicert::Order do
   end
 
   describe ".all" do
-    it "retrieves the list of all certificate orders" do
-      stub_digicert_order_list_api
-      orders = Digicert::Order.all
+    context "without any query params" do
+      it "retrieves the list of all certificate orders" do
+        stub_digicert_order_list_api
+        orders = Digicert::Order.all
 
-      expect(orders.first.id).not_to be_nil
-      expect(orders.first.status).to eq("issued")
-      expect(orders.first.certificate.common_name).to eq("digicert.com")
+        expect(orders.first.id).not_to be_nil
+        expect(orders.first.status).to eq("issued")
+        expect(orders.first.certificate.common_name).to eq("digicert.com")
+      end
+    end
+
+    context "with specified query params" do
+      it "retrieves the filtered list of certificate orders" do
+        query_params = { limit: 3, offset: 0, sort: "date_created" }
+        stub_digicert_order_list_api(query_params)
+
+        orders = Digicert::Order.all(query_params)
+
+        expect(orders.count).to eq(query_params[:limit])
+        expect(orders.first.certificate.common_name).to eq("digicert.com")
+      end
     end
   end
 

--- a/spec/support/fake_digicert_api.rb
+++ b/spec/support/fake_digicert_api.rb
@@ -53,9 +53,12 @@ module Digicert
       )
     end
 
-    def stub_digicert_order_list_api
+    def stub_digicert_order_list_api(params = {})
       stub_api_response(
-        :get, "order/certificate", filename: "orders", status: 200
+        :get,
+        path_with_query("order/certificate", params),
+        filename: "orders",
+        status: 200,
       )
     end
 
@@ -65,9 +68,12 @@ module Digicert
       )
     end
 
-    def stub_digicert_organization_list_api
+    def stub_digicert_organization_list_api(params = {})
       stub_api_response(
-        :get, "organization", filename: "organizations", status: 200
+        :get,
+        path_with_query("organization", params),
+        filename: "organizations",
+        status: 200,
       )
     end
 


### PR DESCRIPTION
Digicert supports to pass query params in the listing interfaces, we already had that one implemented in the `all` action, but it was not documented.

This commit adds the necessary test cases and document this to the readme, we now can use this to retrieve filtered orders.

```ruby
Digicert::Order.all(limit: 20, offset: 0, sort: 'date_created')
```

Reference: Issue #100 