### PR TITLE
Add `.to_query` helper for nested params

### DIFF
--- a/lib/digicert/request.rb
+++ b/lib/digicert/request.rb
@@ -1,6 +1,8 @@
 require "uri"
 require "json"
 require "net/http"
+
+require "digicert/util"
 require "digicert/response"
 require "digicert/errors"
 
@@ -88,7 +90,7 @@ module Digicert
 
     def build_query_params
       if @query_params
-        URI.encode_www_form(@query_params)
+        Digicert::Util.to_query(@query_params)
       end
     end
 

--- a/lib/digicert/util.rb
+++ b/lib/digicert/util.rb
@@ -1,0 +1,34 @@
+require "cgi"
+
+module Digicert
+  class Util
+    def to_query(query)
+      build_query(query).flatten.join("&")
+    end
+
+    def self.to_query(query)
+      new.to_query(query)
+    end
+
+    private
+
+    def build_query(value, key = nil)
+      if value.is_a?(Hash)
+        build_recursive_query(value, key)
+      else
+        build_escaped_key_value_pair(key, value)
+      end
+    end
+
+    def build_recursive_query(query, namespace = nil)
+      query.map do |key, value|
+        query_key = namespace ? "#{namespace}[#{key}]" : key
+        build_query(value, query_key)
+      end
+    end
+
+    def build_escaped_key_value_pair(key, value)
+      [CGI.escape(key.to_s), CGI.escape(value.to_s)].join("=")
+    end
+  end
+end

--- a/spec/digicert/util_spec.rb
+++ b/spec/digicert/util_spec.rb
@@ -1,0 +1,26 @@
+require "cgi"
+require "spec_helper"
+
+RSpec.describe Digicert::Util do
+  describe ".to_query" do
+    context "plain hash with key and value" do
+      it "builds and returns the queryable params" do
+        params = { limit: 10, sort: "date_created" }
+        query_params = Digicert::Util.to_query(params)
+
+        expect(query_params).to eq("limit=10&sort=date_created")
+      end
+    end
+
+    context "with nested hash as key" do
+      it "resolves it and returns the queryable params" do
+        params = { limit: 10, filters: { status: "issued", search: "ribose" } }
+        query_params = Digicert::Util.to_query(params)
+
+        expect(
+          CGI.unescape(query_params),
+        ).to eq("limit=10&filters[status]=issued&filters[search]=ribose")
+      end
+    end
+  end
+end


### PR DESCRIPTION
The default params builder does not support nested params building right out of the box, but Digicert requires us to provide filters as nested params to work properly.

This commit adds a very simple Util helper that will work pretty much same as `URI.encode_www_form` but with support for nested attributes. There are lots of other use cases we could've handle but for now this should do the job.

Inspiration: https://git.io/v97EV