### PR TITLE
Add query filter support for digicert resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,11 +517,33 @@ Use this interface to retrieve a list of all certificate orders.
 Digicert::Order.all
 ```
 
-This interface also supports query params like `limit`, `offset` and `sort`. We
-can use those to retrieve our desire orders.
+This interface also supports query params like `limit`, `offset`, `sort` and
+filters. We can use those to retrieve more precised orders.
 
 ```ruby
-Digicert::Order.all(limit: 20, offset: 0, sort: 'date_created')
+Digicert::Order.all(
+  limit: 20,
+  offset: 0,
+  sort: 'date_created',
+
+  filters: {
+    status: "approved",
+    common_name: "ribosetest.com"
+  }
+)
+```
+
+There is also another interface `.filter`, which is basically an alias around
+the `.all` interface but it passes each of the argument as a filters attributes
+
+```ruby
+Digicert::Order.filter(status: "approved", common_name: "ribosetest.com")
+
+# Similar functionality with all interface
+#
+Digicert::Order.all(
+  filters: { status: "approved", common_name: "ribosetest.com" }
+)
 ```
 
 #### List of Email Validations

--- a/lib/digicert/actions/all.rb
+++ b/lib/digicert/actions/all.rb
@@ -21,6 +21,10 @@ module Digicert
         def all(query_params = {})
           new(params: query_params).all
         end
+
+        def filter(filter_params = {})
+          new(params: { filters: filter_params }).all
+        end
       end
     end
   end

--- a/spec/digicert/actions/all_spec.rb
+++ b/spec/digicert/actions/all_spec.rb
@@ -26,6 +26,20 @@ RSpec.describe "Digicert::Actions::ALL" do
     end
   end
 
+  describe ".filter" do
+    context "with filters params" do
+      it "retrieves the filterered resources" do
+        filters = { status: "approved" }
+        stub_digicert_organization_list_api(filters: filters)
+
+        organizations = Digicert::TestAllAction.filter(filters)
+
+        expect(organizations.count).to eq(2)
+        expect(organizations.first.name).not_to be_nil
+      end
+    end
+  end
+
   module Digicert
     class TestAllAction < Digicert::Base
       include Digicert::Actions::All

--- a/spec/support/fake_digicert_api.rb
+++ b/spec/support/fake_digicert_api.rb
@@ -289,7 +289,7 @@ module Digicert
     end
 
     def path_with_query(path, params)
-      query_params = params.map { |key, value| "#{key}=#{value}" }.join("&")
+      query_params = Digicert::Util.to_query(params)
       [path, query_params].join("?")
     end
 


### PR DESCRIPTION
Digicert has undocumented support to filter resources, and this commit adds the query filter support to our `.all` action, so if any of the class included this module then they will have access to filter results by passing the `filters` hash.

To make it more easier we have also added a wrapper interface around the `.all` interface, which will work exactly same but will wrap the provided arguments as `filters` key as pass those to the `.all` interface.

```ruby
Digicert::Order.filter(status: "approved")

# Similar functionality with `.all` interface 
Digicert::Order.all(filters: { status: "approved" })
```

Reference: Issue #100