### PR TITLE
Fix reissue/duplication issue for custom attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -595,13 +595,11 @@ already exists for that order.
 ```ruby
 Digicert::OrderReissuer.create(
   order: order_id,
-  certificate: {
-    common_name: certificate_common_name,
-    dns_names: [certificate_dns_name],
-    csr: certificate_csr,
-    signature_hash: certificate_signature_hash,
-    server_platform: { id: certificate_server_platform_id },
-  }
+  common_name: certificate_common_name,
+  dns_names: [certificate_dns_name],
+  csr: certificate_csr,
+  signature_hash: certificate_signature_hash,
+  server_platform: { id: certificate_server_platform_id },
 )
 ```
 
@@ -615,13 +613,11 @@ hash. The common name and sans need to be the same as the original order.
 ```ruby
 Digicert::OrderDuplicator.create(
   order: order_id,
-  certificate: {
-    common_name: certificate_common_name,
-    dns_names: [certificate_dns_name],
-    csr: certificate_csr,
-    signature_hash: certificate_signature_hash,
-    server_platform: { id: certificate_server_platform_id },
-  }
+  common_name: certificate_common_name,
+  dns_names: [certificate_dns_name],
+  csr: certificate_csr,
+  signature_hash: certificate_signature_hash,
+  server_platform: { id: certificate_server_platform_id },
 )
 ```
 

--- a/lib/digicert/order_manager.rb
+++ b/lib/digicert/order_manager.rb
@@ -11,18 +11,16 @@ module Digicert
     private
 
     def validate(attributes)
-      order_attributes.merge(attributes)
+      { certificate: order_attributes.merge(attributes) }
     end
 
     def order_attributes
       {
-        certificate: {
-          common_name: order.certificate.common_name,
-          dns_names: order.certificate.dns_names,
-          csr: order.certificate.csr,
-          signature_hash: order.certificate.signature_hash,
-          server_platform: { id: order.certificate.server_platform.id },
-        },
+        common_name: order.certificate.common_name,
+        dns_names: order.certificate.dns_names,
+        csr: order.certificate.csr,
+        signature_hash: order.certificate.signature_hash,
+        server_platform: { id: order.certificate.server_platform.id },
       }
     end
 

--- a/spec/acceptance/duplicating_certificate_spec.rb
+++ b/spec/acceptance/duplicating_certificate_spec.rb
@@ -67,13 +67,11 @@ RSpec.describe "Certificate Order Duplication" do
 
   def certificate_attributes
     {
-      certificate: {
-        common_name: order.certificate.common_name,
-        dns_names: order.certificate.dns_names,
-        csr: order.certificate.csr,
-        signature_hash: order.certificate.signature_hash,
-        server_platform: { id: order.certificate.server_platform.id },
-      },
+      common_name: order.certificate.common_name,
+      dns_names: order.certificate.dns_names,
+      csr: order.certificate.csr,
+      signature_hash: order.certificate.signature_hash,
+      server_platform: { id: order.certificate.server_platform.id },
     }
   end
 

--- a/spec/acceptance/reissuing_certificate_spec.rb
+++ b/spec/acceptance/reissuing_certificate_spec.rb
@@ -13,9 +13,9 @@ RSpec.describe "Re-issuing a certificate" do
     # Reissue an existing certificate order, it
     # usages the order_id from the existing order
     #
-    stub_digicert_order_reissue_api(order.id, new_order_attributes)
+    stub_digicert_order_reissue_api(order.id, certificate_attributes)
     reissued_order = Digicert::OrderReissuer.create(
-      order_id: order.id, **new_order_attributes,
+      order_id: order.id, **certificate_attributes,
     )
 
     # Retrieve the request details from the
@@ -76,15 +76,13 @@ RSpec.describe "Re-issuing a certificate" do
     }
   end
 
-  def new_order_attributes
+  def certificate_attributes
     {
-      certificate: {
-        common_name: order.certificate.common_name,
-        dns_names: order.certificate.dns_names,
-        csr: order.certificate.csr,
-        signature_hash: order.certificate.signature_hash,
-        server_platform: { id: order.certificate.server_platform.id },
-      },
+      common_name: order.certificate.common_name,
+      dns_names: order.certificate.dns_names,
+      csr: order.certificate.csr,
+      signature_hash: order.certificate.signature_hash,
+      server_platform: { id: order.certificate.server_platform.id },
     }
   end
 

--- a/spec/digicert/order_duplicator_spec.rb
+++ b/spec/digicert/order_duplicator_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Digicert::OrderDuplicator do
     it "creates a duplicate of an existing order" do
       stub_digicert_order_fetch_api(order_id)
 
-      stub_digicert_order_duplicate_api(order_id, order_attributes)
+      stub_digicert_order_duplicate_api(order_id, certificate_attributes)
       order = Digicert::OrderDuplicator.create(order_id: order_id)
 
       expect(order.id).not_to be_nil
@@ -17,15 +17,13 @@ RSpec.describe Digicert::OrderDuplicator do
     123_456_789
   end
 
-  def order_attributes
+  def certificate_attributes
     {
-      certificate: {
-        common_name: order.certificate.common_name,
-        dns_names: order.certificate.dns_names,
-        csr: order.certificate.csr,
-        signature_hash: order.certificate.signature_hash,
-        server_platform: { id: order.certificate.server_platform.id },
-      },
+      common_name: order.certificate.common_name,
+      dns_names: order.certificate.dns_names,
+      csr: order.certificate.csr,
+      signature_hash: order.certificate.signature_hash,
+      server_platform: { id: order.certificate.server_platform.id },
     }
   end
 

--- a/spec/digicert/order_reissuer_spec.rb
+++ b/spec/digicert/order_reissuer_spec.rb
@@ -2,14 +2,30 @@ require "spec_helper"
 
 RSpec.describe Digicert::OrderReissuer do
   describe ".create" do
-    it "reissue an existing order" do
-      stub_digicert_order_fetch_api(order_id)
+    context "without custom attributes" do
+      it "reissues with existing order attributes" do
+        stub_digicert_order_fetch_api(order_id)
+        stub_digicert_order_reissue_api(order_id, certificate_attributes)
 
-      stub_digicert_order_reissue_api(order_id, order_attributes)
-      order = Digicert::OrderReissuer.create(order_id: order_id)
+        order = Digicert::OrderReissuer.create(order_id: order_id)
 
-      expect(order.id).not_to be_nil
-      expect(order.requests.first.id).not_to be_nil
+        expect(order.id).not_to be_nil
+        expect(order.requests.first.id).not_to be_nil
+      end
+    end
+
+    context "with custom attributes" do
+      it "reissues with merging the existing and custom attributes" do
+        stub_digicert_order_fetch_api(order_id)
+        stub_digicert_order_reissue_api(order_id, certificate_attributes)
+
+        order = Digicert::OrderReissuer.create(
+          order_id: order_id, **certificate_attributes
+        )
+
+        expect(order.id).not_to be_nil
+        expect(order.requests.first.id).not_to be_nil
+      end
     end
   end
 
@@ -21,15 +37,17 @@ RSpec.describe Digicert::OrderReissuer do
     @order ||= Digicert::Order.fetch(order_id)
   end
 
-  def order_attributes
+  def certificate_attributes
     {
-      certificate: {
-        common_name: order.certificate.common_name,
-        dns_names: order.certificate.dns_names,
-        csr: order.certificate.csr,
-        signature_hash: order.certificate.signature_hash,
-        server_platform: { id: order.certificate.server_platform.id },
-      },
+      common_name: order.certificate.common_name,
+      dns_names: order.certificate.dns_names,
+      csr: order.certificate.csr,
+      signature_hash: order.certificate.signature_hash,
+      server_platform: { id: order.certificate.server_platform.id },
     }
+  end
+
+  def new_attributes
+    @new_attributes ||= certificate_attributes.merge(signature_hash: "sha512")
   end
 end

--- a/spec/support/fake_digicert_api.rb
+++ b/spec/support/fake_digicert_api.rb
@@ -198,7 +198,7 @@ module Digicert
       stub_api_response(
         :post,
         ["order", "certificate", order_id, "reissue"].join("/"),
-        data: attributes,
+        data: { certificate: attributes },
         filename: "order_reissued",
         status: 201,
       )
@@ -208,7 +208,7 @@ module Digicert
       stub_api_response(
         :post,
         ["order", "certificate", order_id, "duplicate"].join("/"),
-        data: attributes,
+        data: { certificate: attributes },
         filename: "order_duplicated",
         status: 201,
       )


### PR DESCRIPTION
Normally the Order `reissue` and `duplication` interface takes an order id and then usages the details from that order, and additionally it also supports for custom attributes. The way it supposed to work is if we add any custom attributes then it will use that along with all others but if we don't then it will use the defaults.

It is working fine when no attributes is provided, but when we provide custom attributes then it is replacing all of the attributes with the new one, which might not include all the attributes, that's why we are having issue like https://github.com/riboseinc/digicert-cli/issues/46

This commit fix that issue, and it also updates the existing interface to provide the custom attributes along with the `order_id`, and it will do the work of organizing those, bit less work for users!