### PR TITLE
fix example of fetching first org

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ Digicert::CSRGenerator.generate(
   common_name: "example.com",
   san_names: ["example.com", "www.example.com"],
   rsa_key: File.read("your_rsa_key_file_path"),
-  organization: Digicert::Organization.first,
+  organization: Digicert::Organization.all.first,
 )
 ```
 


### PR DESCRIPTION
I am integrating the `digicert` library into a project (thank you for this!) and found that `Digicert::Organization.first` (found in the readme) returns a `NoMethodError`. In order to get the first org, it looks like you actually have to use `Digicert::Organization.all.first` so I updated this part of the README.