### PR TITLE
add support for Private Premium client certificate

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,6 +437,28 @@ Digicert::ClientCertificate::Premium.create(
 )
 ```
 
+#### Order Private Client Premium Certificate
+
+Use this interface to order a Private Client Premium Certificate.
+
+```ruby
+Digicert::ClientCertificate::PrivatePremium.create(
+  certificate: {
+    organization_units: ["Developer Operations"],
+
+    csr: "------ [CSR HERE] ------",
+    emails: ["a.name@example.com"],
+    common_name: "Common Name",
+    signature_hash: "sha256",
+  },
+  organization: { id: "12345" },
+  validity_years: 3,
+  auto_renew: nil,
+  container: { id: "654321" },
+  payment_method: "balance",
+)
+```
+
 #### Order Email Security Plus
 
 Use this interface to order a Email Security Plus Certificate

--- a/lib/digicert/client_certificate/private_premium.rb
+++ b/lib/digicert/client_certificate/private_premium.rb
@@ -1,0 +1,13 @@
+require "digicert/client_certificate/base"
+
+module Digicert
+  module ClientCertificate
+    class PrivatePremium < Digicert::ClientCertificate::Base
+      private
+
+      def certificate_type
+        'private_client_premium'
+      end
+    end
+  end
+end

--- a/lib/digicert/order.rb
+++ b/lib/digicert/order.rb
@@ -6,6 +6,7 @@ require "digicert/ssl_certificate/ssl_ev_plus"
 require "digicert/ssl_certificate/ssl_wildcard"
 
 require "digicert/client_certificate/premium"
+require "digicert/client_certificate/private_premium"
 require "digicert/client_certificate/email_security_plus"
 require "digicert/client_certificate/digital_signature_plus"
 

--- a/spec/digicert/client_certificate/private_premium_spec.rb
+++ b/spec/digicert/client_certificate/private_premium_spec.rb
@@ -1,0 +1,30 @@
+require "spec_helper"
+
+RSpec.describe Digicert::ClientCertificate::PrivatePremium do
+  describe ".create" do
+    it "creates a new order for a client private premium certificate" do
+      stub_digicert_order_create_api("private_client_premium", order_attributes)
+      order = Digicert::ClientCertificate::PrivatePremium.create(order_attributes)
+
+      expect(order.id).not_to be_nil
+    end
+  end
+
+  def order_attributes
+    {
+      certificate: {
+        organization_units: ["Developers"],
+
+        csr: "----- CSR HERE -----",
+        emails: ["a.name@example.com"],
+        common_name: "A Name",
+        signature_hash: "sha256",
+      },
+      organization: { id: "12345" },
+      validity_years: 3,
+      auto_renew: nil,
+      container: { id: "654321" },
+      payment_method: "balance"
+    }
+  end
+end


### PR DESCRIPTION
Hi again! 

Our company is paying Digicert for private PKI services, i.e. a CA hosted by Digicert to which only we have access for issuing certificates. This allows us to use their "Private Client Premium" certificate endpoint which isn't documented in the API docs (for whatever reason). 

The gem's organization made it super easy for us to implement this class locally (thanks!) but I thought I'd see what you think about incorporating the change to get to this endpoint.