### PR TITLE
Bump the gem version to `0.3.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.3.0 (2017-12-08)
+
+* Minor updates in the readme and `rubocop` configuration
+* Add support for Private Premium client certificate (#130, @davidcpell)
+
 ## 0.2.0 (2017-08-09)
 
 * Fix reissue/duplication issue for custom attribute (PR #124)

--- a/lib/digicert/version.rb
+++ b/lib/digicert/version.rb
@@ -21,5 +21,5 @@
 # ++
 
 module Digicert
-  VERSION = "0.2.0".freeze
+  VERSION = "0.3.0".freeze
 end


### PR DESCRIPTION
* Minor updates in the readme and `rubocop` config
* Add support for Private Premium client certificate.