### PR TITLE
Fix duplicate certificate finder bug

### DIFF
--- a/lib/digicert/duplicate_certificate_finder.rb
+++ b/lib/digicert/duplicate_certificate_finder.rb
@@ -22,7 +22,7 @@ module Digicert
 
     def certificates_by_date_created
       duplicate_certificates.select do |certificate|
-        certificate.date_created == request_created_at
+        compare_date(certificate.date_created, request_created_at) < 5
       end
     end
 
@@ -33,6 +33,13 @@ module Digicert
 
     def request_created_at
       request.order.certificate.date_created
+    end
+
+    def compare_date(from_date, to_date)
+      from_time = DateTime.parse(from_date).to_time
+      to_time = DateTime.parse(to_date).to_time
+
+      from_time.to_i - to_time.to_i
     end
 
     def request


### PR DESCRIPTION
To find a duplicate certificate, we are using retrieving details for any requests and then use the created_at date for the request and order to find out the duplicate order.

But for some reason, looks like there might be couple of seconds or differences between those dates, so this commit changes our finder to look for any certificate with 5 seconds time and this should fix the issue for now.

In the future, we should look for more stable solution, and if necessary then we can also adjust the time.

Fixes #137