### PR TITLE
Fix empty duplicate certificate issue

### DIFF
--- a/lib/digicert/duplicate_certificate_finder.rb
+++ b/lib/digicert/duplicate_certificate_finder.rb
@@ -21,7 +21,7 @@ module Digicert
     end
 
     def certificates_by_date_created
-      duplicate_certificates.select do |certificate|
+      (duplicate_certificates || []).select do |certificate|
         compare_date(certificate.date_created, request_created_at) < 5
       end
     end


### PR DESCRIPTION
When there are no duplicate certificate for any request, then the certificate finder throws an error. But it might be more useful to return nil if there are duplicate certificate for a request.

This commit takes that into consideration, and return nil when there no duplicate certificate for any of the request.

Fixes #136