### PR TITLE
Add option support on duplicate certificate

### DIFF
--- a/lib/digicert/order.rb
+++ b/lib/digicert/order.rb
@@ -33,8 +33,8 @@ module Digicert
       Digicert::OrderDuplicator.create(order_id: resource_id, **attributes)
     end
 
-    def duplicate_certificates
-      Digicert::DuplicateCertificate.all(order_id: resource_id)
+    def duplicate_certificates(attributes = {})
+      Digicert::DuplicateCertificate.all(order_id: resource_id, **attributes)
     end
 
     def email_validations

--- a/spec/digicert/order_spec.rb
+++ b/spec/digicert/order_spec.rb
@@ -100,11 +100,11 @@ RSpec.describe Digicert::Order do
       order = Digicert::Order.find(order_id)
       allow(Digicert::DuplicateCertificate).to receive(:all)
 
-      order.duplicate_certificates
+      order.duplicate_certificates(sort: "date_created")
 
       expect(
         Digicert::DuplicateCertificate,
-      ).to have_received(:all).with(order_id: order_id)
+      ).to have_received(:all).with(order_id: order_id, sort: "date_created")
     end
   end
 


### PR DESCRIPTION
This instance interface on `order` does not support any option but in reality user might want to pass additional options to the duplicate certificate as they can do on the parent interface. This commit fixes that issues and add support for options.

Fixes: #141