### PR TITLE
Fix duplicate certificate finder issue

### DIFF
--- a/lib/digicert/duplicate_certificate_finder.rb
+++ b/lib/digicert/duplicate_certificate_finder.rb
@@ -5,7 +5,11 @@ module Digicert
     end
 
     def find
-      certificate_by_date_created
+      certificate_by_date_created || raise(
+        Digicert::Errors::RequestError.new(
+          request: "The request is still pending, needs an approval first!",
+        ),
+      )
     end
 
     def self.find_by(request_id:)
@@ -17,7 +21,9 @@ module Digicert
     attr_reader :request_id
 
     def certificate_by_date_created
-      certificates_by_date_created.first
+      if request.status == "approved"
+        certificates_by_date_created.first
+      end
     end
 
     def certificates_by_date_created

--- a/spec/digicert/certificate_request_spec.rb
+++ b/spec/digicert/certificate_request_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Digicert::CertificateRequest do
       certificate_request = Digicert::CertificateRequest.fetch(request_id)
 
       expect(certificate_request.order.id).not_to be_nil
-      expect(certificate_request.status).to eq("pending")
+      expect(certificate_request.status).to eq("approved")
       expect(certificate_request.requester.first_name).not_to be_nil
     end
   end

--- a/spec/digicert/duplicate_certificate_finder_spec.rb
+++ b/spec/digicert/duplicate_certificate_finder_spec.rb
@@ -2,17 +2,32 @@ require "spec_helper"
 
 RSpec.describe Digicert::DuplicateCertificateFinder do
   describe ".find" do
-    it "finds the duplicate certificate" do
-      request_id = 123_456_789
+    context "approved request" do
+      it "finds the duplicate certificate" do
+        request_id = 123_456_789
 
-      stub_digicert_certificate_request_fetch_api(request_id)
-      stub_digicert_order_duplications_api(order_id)
+        stub_digicert_certificate_request_fetch_api(request_id)
+        stub_digicert_order_duplications_api(order_id)
 
-      certificate = Digicert::DuplicateCertificateFinder.find_by(
-        request_id: request_id,
-      )
+        certificate = Digicert::DuplicateCertificateFinder.find_by(
+          request_id: request_id,
+        )
 
-      expect(certificate.id).not_to be_nil
+        expect(certificate.id).not_to be_nil
+      end
+    end
+
+    context "pending request" do
+      it "returns RequestError with a message" do
+        request_id = 456_789_012
+        stub_digicert_certificate_request_fetch_api(
+          request_id, "certificate_request_pending"
+        )
+
+        expect do
+          Digicert::DuplicateCertificateFinder.find_by(request_id: request_id)
+        end.to raise_error(Digicert::Errors::RequestError)
+      end
     end
   end
 

--- a/spec/fixtures/certificate_request_pending.json
+++ b/spec/fixtures/certificate_request_pending.json
@@ -1,8 +1,8 @@
 {
-  "id": 123456789,
+  "id": 456789012,
   "date": "2014-08-19T18:16:07+00:00",
   "type": "new_request",
-  "status": "approved",
+  "status": "pending",
   "date_processed": "2014-08-19T18:17:07+00:00",
   "requester": {
     "id": 151435,

--- a/spec/support/fake_digicert_api.rb
+++ b/spec/support/fake_digicert_api.rb
@@ -18,11 +18,13 @@ module Digicert
       )
     end
 
-    def stub_digicert_certificate_request_fetch_api(request_id)
+    def stub_digicert_certificate_request_fetch_api(request_id, json_file = nil)
+      json_file ||= "certificate_request"
+
       stub_api_response(
         :get,
         ["request", request_id].join("/"),
-        filename: "certificate_request",
+        filename: json_file,
         status: 200,
       )
     end


### PR DESCRIPTION
Recently, we came across an issue in the duplicate certificate finder. Let's say one certificate has an existing duplicate and in a later date we also request another one which is pending. Now if we use the finder to find the duplicate certificate then it would return the old one, which is miss leading.

This commit fixes this by checking the status of the request and if it's still pending then it throws an error.

Discussion: #138