### PR TITLE
Fix SSL EV Plus duplication issue

### DIFF
--- a/lib/digicert/order_manager.rb
+++ b/lib/digicert/order_manager.rb
@@ -17,7 +17,7 @@ module Digicert
     def order_attributes
       {
         common_name: order.certificate.common_name,
-        dns_names: order.certificate.dns_names,
+        dns_names: simplified_certificate_dns_names,
         csr: order.certificate.csr,
         signature_hash: order.certificate.signature_hash,
         server_platform: { id: order.certificate.server_platform.id },
@@ -26,6 +26,19 @@ module Digicert
 
     def order
       @order ||= Digicert::Order.fetch(order_id)
+    end
+
+    def simplified_certificate_dns_names
+      if order.product.name_id == "ssl_ev_plus"
+        simplify_dns_name_to_duplicate_ev_plus
+      else
+        order.certificate.dns_names
+      end
+    end
+
+    def simplify_dns_name_to_duplicate_ev_plus
+      dns_names = order.certificate.dns_names
+      dns_names.map { |dns_name| dns_name.gsub("www.", "") }.uniq
     end
 
     # Expose the resource_id as order_id, as it sounds

--- a/lib/digicert/order_manager.rb
+++ b/lib/digicert/order_manager.rb
@@ -38,7 +38,7 @@ module Digicert
 
     def simplify_dns_name_to_duplicate_ev_plus
       dns_names = order.certificate.dns_names
-      dns_names.map { |dns_name| dns_name.gsub("www.", "") }.uniq
+      dns_names.select { |dns_name| dns_name.match(/.+\..+\..+/) }.uniq
     end
 
     # Expose the resource_id as order_id, as it sounds

--- a/spec/digicert/order_duplicator_spec.rb
+++ b/spec/digicert/order_duplicator_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Digicert::OrderDuplicator do
 
   def stub_digicert_ev_plus_duplicate_api
     attributes = certificate_attributes
-    attributes[:dns_names] = [attributes[:dns_names].first]
+    attributes[:dns_names] = [attributes[:dns_names].last]
     stub_digicert_order_duplicate_api(order_id, attributes)
   end
 

--- a/spec/digicert/order_duplicator_spec.rb
+++ b/spec/digicert/order_duplicator_spec.rb
@@ -11,6 +11,17 @@ RSpec.describe Digicert::OrderDuplicator do
       expect(order.id).not_to be_nil
       expect(order.requests.first.id).not_to be_nil
     end
+
+    context "ev plus certificate" do
+      it "cleanup data and duplicates an order" do
+        stub_digicert_order_fetch_api(order_id, "ssl_ev_order")
+
+        stub_digicert_ev_plus_duplicate_api
+        order = Digicert::OrderDuplicator.create(order_id: order_id)
+
+        expect(order.id).not_to be_nil
+      end
+    end
   end
 
   def order_id
@@ -25,6 +36,12 @@ RSpec.describe Digicert::OrderDuplicator do
       signature_hash: order.certificate.signature_hash,
       server_platform: { id: order.certificate.server_platform.id },
     }
+  end
+
+  def stub_digicert_ev_plus_duplicate_api
+    attributes = certificate_attributes
+    attributes[:dns_names] = [attributes[:dns_names].first]
+    stub_digicert_order_duplicate_api(order_id, attributes)
   end
 
   def order

--- a/spec/fixtures/ssl_ev_order.json
+++ b/spec/fixtures/ssl_ev_order.json
@@ -1,0 +1,108 @@
+{
+  "id": 123456789,
+  "certificate": {
+    "id": 112358,
+    "thumbprint": "7D236B54D19D5EACF0881FAF24D51DFE5D23E945",
+    "serial_number": "0669D46CAE79EF684A69777490602485",
+    "common_name": "digicert.com",
+    "dns_names": [
+      "digicert.com",
+      "www.digicert.com"
+    ],
+    "date_created": "2014-08-19T18:16:07+00:00",
+    "valid_from": "2014-08-19",
+    "valid_till": "2015-08-19",
+    "csr": "------ [CSR HERE] ------",
+    "organization": {
+      "id": 117483
+    },
+    "organization_units": [
+      "Digicert"
+    ],
+    "server_platform": {
+      "id": 45,
+      "name": "nginx",
+      "install_url": "https:\/\/www.digicert.com\/ssl-certificate-installation-nginx.htm",
+      "csr_url": "https:\/\/www.digicert.com\/csr-creation-nginx.htm"
+    },
+    "signature_hash": "sha256",
+    "key_size": 2048,
+    "ca_cert": {
+      "id": "f7slk4shv9s2wr3",
+      "name": "DCert Private CA"
+    }
+  },
+  "status": "approved",
+  "is_renewal": true,
+  "is_renewed": false,
+  "renewed_order_id": 0,
+  "business_unit": "Some Unit",
+  "date_created": "2014-08-19T18:16:07+00:00",
+  "organization": {
+    "name": "DigiCert, Inc.",
+    "display_name": "DigiCert, Inc.",
+    "is_active": true,
+    "city": "Lindon",
+    "state": "Utah",
+    "country": "us"
+  },
+  "disable_renewal_notifications": false,
+  "container": {
+    "id": 5,
+    "name": "College of Science"
+  },
+  "product": {
+    "name_id": "ssl_ev_plus",
+    "name": "SSL EV Plus",
+    "type": "ssl_certificate",
+    "validation_type": "ov",
+    "validation_name": "OV",
+    "validation_description": "Normal Organization Validation"
+  },
+  "organization_contact": {
+    "first_name": "Some",
+    "last_name": "Guy",
+    "email": "someguy@digicert.com",
+    "telephone": "8015551212"
+  },
+  "technical_contact": {
+    "first_name": "Some",
+    "last_name": "Guy",
+    "email": "someguy@digicert.com",
+    "telephone": "8015551212"
+  },
+  "user": {
+    "id": 153208,
+    "first_name": "Clive",
+    "last_name": "Collegedean",
+    "email": "clivecollegedean@digicert.com"
+  },
+  "requests": [
+    {
+      "id": 1,
+      "date": "2015-01-01T18:20:00+00:00",
+      "type": "new_request",
+      "status": "approved",
+      "comments": "Form autofill"
+    }
+  ],
+  "receipt_id": 123892,
+  "cs_provisioning_method": "none",
+  "send_minus_90": true,
+  "send_minus_60": true,
+  "send_minus_30": true,
+  "send_minus_7": true,
+  "send_minus_3": true,
+  "send_plus_7": true,
+  "public_id": "MZv8RhHDVl9R3Ieko3iMX89wvYT3bYPA",
+  "allow_duplicates": false,
+  "user_assignments": [
+    {
+      "id": 153208,
+      "first_name": "Clive",
+      "last_name": "Collegedean",
+      "email": "clivecollegedean@digicert.com"
+    }
+  ],
+  "payment_method": "balance"
+}

--- a/spec/support/fake_digicert_api.rb
+++ b/spec/support/fake_digicert_api.rb
@@ -58,9 +58,9 @@ module Digicert
       )
     end
 
-    def stub_digicert_order_fetch_api(order_id)
+    def stub_digicert_order_fetch_api(order_id, file = "order")
       stub_api_response(
-        :get, ["order/certificate", order_id].join("/"), filename: "order"
+        :get, ["order/certificate", order_id].join("/"), filename: file
       )
     end
 


### PR DESCRIPTION
Currently, the duplication for SSL EV Plus request throws an `Invalid DNS name` issue. After looking into this we found this interface does not expect us to provide both `root` and `www` in the same request, otherwise it won't process that request.

This commit adds simple fix, and it will remove `www.` from the `dns_names` list and this should fix the issue for now.

Fixes: #135