### PR TITLE
Fix server platform id related issue

### DIFF
--- a/lib/digicert/order_manager.rb
+++ b/lib/digicert/order_manager.rb
@@ -20,7 +20,13 @@ module Digicert
         dns_names: simplified_certificate_dns_names,
         csr: order.certificate.csr,
         signature_hash: order.certificate.signature_hash,
-        server_platform: { id: order.certificate.server_platform.id },
+
+        # In a recent changes, the order response does not seem
+        # to have the paltform id in it, so let's not try to fetch
+        # the platform id for now, and once confirmed then we can
+        # also adjust this as necessary.
+        #
+        # server_platform: { id: order.certificate.server_platform.id },
       }
     end
 

--- a/spec/digicert/order_duplicator_spec.rb
+++ b/spec/digicert/order_duplicator_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Digicert::OrderDuplicator do
       dns_names: order.certificate.dns_names,
       csr: order.certificate.csr,
       signature_hash: order.certificate.signature_hash,
-      server_platform: { id: order.certificate.server_platform.id },
+      # server_platform: { id: order.certificate.server_platform.id },
     }
   end
 

--- a/spec/digicert/order_reissuer_spec.rb
+++ b/spec/digicert/order_reissuer_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Digicert::OrderReissuer do
       dns_names: order.certificate.dns_names,
       csr: order.certificate.csr,
       signature_hash: order.certificate.signature_hash,
-      server_platform: { id: order.certificate.server_platform.id },
+      # server_platform: { id: order.certificate.server_platform.id },
     }
   end
 


### PR DESCRIPTION
In a recent changes, trying to fetch platform id from an order throws an error. The order response has not been confirmed so let's disable this for now and this should fix the issue for the moment.

Ref: #146