### PR TITLE
Add server platform id back for order

### DIFF
--- a/lib/digicert/order_manager.rb
+++ b/lib/digicert/order_manager.rb
@@ -20,13 +20,7 @@ module Digicert
         dns_names: simplified_certificate_dns_names,
         csr: order.certificate.csr,
         signature_hash: order.certificate.signature_hash,
-
-        # In a recent changes, the order response does not seem
-        # to have the paltform id in it, so let's not try to fetch
-        # the platform id for now, and once confirmed then we can
-        # also adjust this as necessary.
-        #
-        # server_platform: { id: order.certificate.server_platform.id },
+        server_platform: { id: order.certificate.server_platform.id },
       }
     end
 

--- a/spec/digicert/order_duplicator_spec.rb
+++ b/spec/digicert/order_duplicator_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Digicert::OrderDuplicator do
       dns_names: order.certificate.dns_names,
       csr: order.certificate.csr,
       signature_hash: order.certificate.signature_hash,
-      # server_platform: { id: order.certificate.server_platform.id },
+      server_platform: { id: order.certificate.server_platform.id },
     }
   end
 

--- a/spec/digicert/order_reissuer_spec.rb
+++ b/spec/digicert/order_reissuer_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Digicert::OrderReissuer do
       dns_names: order.certificate.dns_names,
       csr: order.certificate.csr,
       signature_hash: order.certificate.signature_hash,
-      # server_platform: { id: order.certificate.server_platform.id },
+      server_platform: { id: order.certificate.server_platform.id },
     }
   end
 


### PR DESCRIPTION
There was an ongoing issue with the response for an `order`, but since it's fixed as mentioned on #146, so let's uncomment this & put that line back, so we can also sent the server platform with any of the new requests.