### PR TITLE
Remove bundler's hard dependency

### DIFF
--- a/digicert.gemspec
+++ b/digicert.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "pry"
   spec.add_development_dependency "dotenv"
-  spec.add_development_dependency "bundler", "~> 1.14"
   spec.add_development_dependency "rake", "~> 12.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "webmock", "~> 2.0"


### PR DESCRIPTION
In this gem, we are setting up a hard dependency for bundler, which is not really necessary and it also causes some issue if you have different bundler installed.

By default every ruby environment is equipped with bundler, so this commit remove his hard dependency.