### PR TITLE
Add support for ruby version 3.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.1", "2.2", "2.5", "2.7"]
+        ruby: ["2.6", "2.7", "3.0", "3.1"]
         os: [ ubuntu-latest, windows-latest, macos-latest ]
 
     steps:

--- a/digicert.gemspec
+++ b/digicert.gemspec
@@ -25,5 +25,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "dotenv"
   spec.add_development_dependency "rake", "~> 12.0"
   spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency "webmock", "~> 2.0"
+  spec.add_development_dependency "webmock", "~> 3.0"
 end

--- a/lib/digicert/actions/create.rb
+++ b/lib/digicert/actions/create.rb
@@ -7,7 +7,7 @@ module Digicert
 
       def create
         Digicert::Request.new(
-          :post, resource_creation_path, validate(attributes)
+          :post, resource_creation_path, **validate(**attributes)
         ).parse
       end
 

--- a/lib/digicert/actions/update.rb
+++ b/lib/digicert/actions/update.rb
@@ -7,7 +7,7 @@ module Digicert
 
       def update
         Digicert::Request.new(
-          :put, resource_update_path, attributes
+          :put, resource_update_path, **attributes
         ).run
       end
 

--- a/lib/digicert/base_order.rb
+++ b/lib/digicert/base_order.rb
@@ -8,8 +8,8 @@ module Digicert
 
     def validate(certificate:, organization:, validity_years:, **attributes)
       required_attributes = {
-        certificate: validate_certificate(certificate),
-        organization: validate_organization(organization),
+        certificate: validate_certificate(**certificate),
+        organization: validate_organization(**organization),
         validity_years: validity_years,
       }
 

--- a/lib/digicert/certificate.rb
+++ b/lib/digicert/certificate.rb
@@ -13,7 +13,7 @@ module Digicert
     end
 
     def revoke
-      request_klass.new(:put, revocation_path, attributes).parse
+      request_klass.new(:put, revocation_path, **attributes).parse
     end
 
     def self.revoke(certificate_id, attributes = {})
@@ -22,7 +22,7 @@ module Digicert
 
     def download_to_path(path:, ext: "zip", **attributes)
       certificate_downloader.fetch_to_path(
-        resource_id, attributes.merge(path: path, ext: ext)
+        resource_id, **attributes.merge(path: path, ext: ext)
       )
     end
 

--- a/lib/digicert/client_certificate/premium.rb
+++ b/lib/digicert/client_certificate/premium.rb
@@ -10,7 +10,7 @@ module Digicert
       end
 
       def validate_certificate(csr:, **attributes)
-        super(attributes.merge(csr: csr))
+        super(**attributes.merge(csr: csr))
       end
     end
   end

--- a/lib/digicert/csr_generator.rb
+++ b/lib/digicert/csr_generator.rb
@@ -14,7 +14,7 @@ module Digicert
     end
 
     def self.generate(attributes)
-      new(attributes).generate
+      new(**attributes).generate
     end
 
     private

--- a/lib/digicert/domain.rb
+++ b/lib/digicert/domain.rb
@@ -29,7 +29,7 @@ module Digicert
 
     def validate_validations(attributes)
       attributes.map do |attribute|
-        validate_validation(attribute)
+        validate_validation(**attribute)
       end
     end
 
@@ -43,7 +43,7 @@ module Digicert
     # Ref: https://www.digicert.com/services/v2/documentation/appendix-validation-types
     #
     def validate_validation(type:, **attributes)
-      { type: type.downcase }.merge(attributes)
+      attributes.merge(type: type.downcase)
     end
 
     def validate(name:, organization:, validations:, **attributes)

--- a/lib/digicert/email_validation.rb
+++ b/lib/digicert/email_validation.rb
@@ -10,7 +10,9 @@ module Digicert
 
     def self.valid?(token:, email:)
       response = Digicert::Request.new(
-        :put, ["email-validation", token].join("/"), params: { email: email }
+        :put,
+        ["email-validation", token].join("/"),
+        **{ params: { email: email } },
       ).run
 
       response.code.to_i == 204

--- a/lib/digicert/order_cancellation.rb
+++ b/lib/digicert/order_cancellation.rb
@@ -4,7 +4,7 @@ module Digicert
   class OrderCancellation < Digicert::Base
     def create
       request_klass.new(
-        :put, resource_path, default_attributes.merge(attributes)
+        :put, resource_path, **default_attributes.merge(attributes)
       ).run
     end
 

--- a/lib/digicert/order_manager.rb
+++ b/lib/digicert/order_manager.rb
@@ -5,12 +5,12 @@ module Digicert
     include Digicert::Actions::Create
 
     def self.create(order_id:, **attributes)
-      new(resource_id: order_id, **attributes).create
+      new(attributes.merge(resource_id: order_id)).create
     end
 
     private
 
-    def validate(attributes)
+    def validate(**attributes)
       { certificate: order_attributes.merge(attributes) }
     end
 

--- a/lib/digicert/organization.rb
+++ b/lib/digicert/organization.rb
@@ -23,7 +23,7 @@ module Digicert
         country: country,
         telephone: telephone,
         container: container,
-        organization_contact: validate_contact(organization_contact),
+        organization_contact: validate_contact(**organization_contact),
       }
 
       required_attributes.merge(attributes)

--- a/spec/digicert/actions/create_spec.rb
+++ b/spec/digicert/actions/create_spec.rb
@@ -4,7 +4,7 @@ require "digicert/base"
 RSpec.describe "Digicert::Actions::Create" do
   describe ".create" do
     it "creates a new resource" do
-      stub_digicert_container_create_api(container_attributes)
+      stub_digicert_container_create_api(**container_attributes)
       resource = Digicert::TestCreateAction.create(container_attributes)
 
       expect(resource.id).not_to be_nil

--- a/spec/digicert/certificate_spec.rb
+++ b/spec/digicert/certificate_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Digicert::Certificate do
       }
 
       stub_digicert_certificate_download_by_platform(certificate_id)
-      certificate.download_to_path(download_to_path_attributes)
+      certificate.download_to_path(**download_to_path_attributes)
 
       download_url =
         [download_to_path_attributes[:path], "certificate.zip"].join("/")

--- a/spec/digicert/container_spec.rb
+++ b/spec/digicert/container_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe Digicert::Container do
 
   describe ".create" do
     it "creates a new sub container" do
-      stub_digicert_container_create_api(container_attributes)
-      container = Digicert::Container.create(container_attributes)
+      stub_digicert_container_create_api(**container_attributes)
+      container = Digicert::Container.create(**container_attributes)
 
       expect(container.id).not_to be_nil
     end

--- a/spec/digicert/domain_spec.rb
+++ b/spec/digicert/domain_spec.rb
@@ -79,8 +79,8 @@ RSpec.describe Digicert::Domain do
       organization: { id: 117483 },
       validations: [
         {
-          type: "ev",
           user: { id: 12 },
+          type: "ev",
         },
       ],
       dcv: { method: "email" },

--- a/spec/digicert/email_validation_spec.rb
+++ b/spec/digicert/email_validation_spec.rb
@@ -16,10 +16,10 @@ RSpec.describe Digicert::EmailValidation do
   describe ".valid?" do
     it "validates the email through digicert" do
       validation_attributes = { token: "token", email: "email@example.com" }
-      stub_digicert_email_validations_validate_api(validation_attributes)
+      stub_digicert_email_validations_validate_api(**validation_attributes)
 
       expect(
-        Digicert::EmailValidation.valid?(validation_attributes),
+        Digicert::EmailValidation.valid?(**validation_attributes),
       ).to eq(true)
     end
   end


### PR DESCRIPTION
This commit adds support for ruby 3.0. This fixes all the warning and pending issue that was raised in the recent version. This commit also limits our test suite to the recently supported versions.

Fixes https://github.com/riboseinc/digicert/issues/155